### PR TITLE
Add draw_text shim and web-based hot-reload for Shimlang

### DIFF
--- a/macroquad_playground/shimlang_bridge.js
+++ b/macroquad_playground/shimlang_bridge.js
@@ -1,0 +1,41 @@
+// Miniquad plugin that lets the host page hand Shimlang source code to the
+// running WASM. The page sets window.__shimlang_pending_source to a string
+// and window.__shimlang_source_ready to true; the WASM polls each frame.
+//
+// Loaded after mq_js_bundle.js and before load("...wasm") in the host page.
+
+(function () {
+    let pending_encoded = null;
+
+    const shimlang_bridge_plugin = {
+        register_plugin: function (importObject) {
+            importObject.env.shimlang_source_len = function () {
+                if (!window.__shimlang_source_ready) {
+                    return -1;
+                }
+                const src = window.__shimlang_pending_source;
+                if (typeof src !== "string") {
+                    return -1;
+                }
+                pending_encoded = new TextEncoder().encode(src);
+                return pending_encoded.length;
+            };
+
+            importObject.env.shimlang_take_source = function (ptr) {
+                if (pending_encoded === null) {
+                    return;
+                }
+                const mem = new Uint8Array(wasm_memory.buffer);
+                mem.set(pending_encoded, ptr);
+                window.__shimlang_source_ready = false;
+                pending_encoded = null;
+            };
+        },
+    };
+
+    if (typeof miniquad_add_plugin === "function") {
+        miniquad_add_plugin(shimlang_bridge_plugin);
+    } else {
+        console.error("shimlang_bridge.js loaded before mq_js_bundle.js — miniquad_add_plugin is undefined");
+    }
+})();

--- a/macroquad_playground/src/main.rs
+++ b/macroquad_playground/src/main.rs
@@ -344,6 +344,51 @@ fn shim_draw_rectangle(_interpreter: &mut Interpreter, args: &ArgBundle) -> Resu
     Ok(ShimValue::None)
 }
 
+fn shim_draw_text(interpreter: &mut Interpreter, args: &ArgBundle) -> Result<ShimValue, String> {
+    let mut unpacker = ArgUnpacker::new(args);
+    let text_val = unpacker
+        .optional(b"text")
+        .ok_or_else(|| "Missing required argument: 'text'".to_string())?;
+    let x = unpacker.required_number(b"x")?;
+    let y = unpacker.required_number(b"y")?;
+    let font_size = unpacker.required_number(b"font_size")?;
+    let r = unpacker.required_number(b"r")?;
+    let g = unpacker.required_number(b"g")?;
+    let b = unpacker.required_number(b"b")?;
+    let a = unpacker.required_number(b"a")?;
+    unpacker.end()?;
+
+    let text_bytes: Vec<u8> = text_val.string(interpreter)?.to_vec();
+    let text = std::str::from_utf8(&text_bytes)
+        .map_err(|e| format!("draw_text: invalid UTF-8: {}", e))?;
+    draw_text(text, x, y, font_size, Color::new(r, g, b, a));
+    Ok(ShimValue::None)
+}
+
+// JS → WASM source bridge (web playground).
+//
+// shimlang_source_len() returns -1 when no new source is pending, else the
+// length in bytes of an internally-cached UTF-8 buffer that
+// shimlang_take_source(ptr) will copy into WASM linear memory.
+#[cfg(target_arch = "wasm32")]
+unsafe extern "C" {
+    fn shimlang_source_len() -> i32;
+    fn shimlang_take_source(ptr: *mut u8);
+}
+
+#[cfg(target_arch = "wasm32")]
+fn try_take_pending_source() -> Option<Vec<u8>> {
+    unsafe {
+        let len = shimlang_source_len();
+        if len <= 0 {
+            return None;
+        }
+        let mut buf = vec![0u8; len as usize];
+        shimlang_take_source(buf.as_mut_ptr());
+        Some(buf)
+    }
+}
+
 fn load_script(text: &[u8]) -> Result<(Interpreter, Environment, ShimValue), String> {
     let interpreter_config = shimlang::Config::default();
     let ast = shimlang::ast_from_text(text)?;
@@ -356,6 +401,7 @@ fn load_script(text: &[u8]) -> Result<(Interpreter, Environment, ShimValue), Str
         (b"draw_circle", Box::new(shim_draw_circle)),
         (b"draw_rectangle", Box::new(shim_draw_rectangle)),
         (b"draw_line", Box::new(shim_draw_line)),
+        (b"draw_text", Box::new(shim_draw_text)),
         (b"clear_background", Box::new(shim_clear_background)),
         (b"new_bloop", Box::new(shim_new_bloop)),
     ];
@@ -450,12 +496,18 @@ async fn main() {
     let (mut interpreter, mut env, mut loop_fn) = load_script(b"fn loop() {}").expect("Should be able to load hardcoded script");
     let mut script_errors = Vec::new();
 
+    #[cfg(not(target_arch = "wasm32"))]
     let script_path = "game.shm";
 
-    // On wasm, load the script once via load_file
-    #[cfg(target_arch = "wasm32")]
-    match load_file(script_path).await {
-        Ok(bytes) => {
+    // On native, track mtime for auto-reloading
+    #[cfg(not(target_arch = "wasm32"))]
+    let mut mtime = SystemTime::now();
+
+    loop {
+        // On wasm, hot-reload from JS-supplied source whenever the host page
+        // marks one ready (e.g. when the user clicks Run in the playground).
+        #[cfg(target_arch = "wasm32")]
+        if let Some(bytes) = try_take_pending_source() {
             match load_script(&bytes) {
                 Ok(res) => {
                     (interpreter, env, loop_fn) = res;
@@ -464,18 +516,9 @@ async fn main() {
                 Err(msg) => {
                     script_errors.push(msg);
                 }
-            };
-        },
-        Err(_msg) => {
-            script_errors.push(format!("Could not read {script_path}"));
+            }
         }
-    }
 
-    // On native, track mtime for auto-reloading
-    #[cfg(not(target_arch = "wasm32"))]
-    let mut mtime = SystemTime::now();
-
-    loop {
         // Auto-reload script on native when file changes
         #[cfg(not(target_arch = "wasm32"))]
         match fs::metadata(script_path) {


### PR DESCRIPTION
## Summary
This PR adds text rendering support to the Shimlang playground and implements a web-based hot-reload mechanism that allows the host page to supply source code to the WASM runtime.

## Key Changes
- **Added `draw_text` shim function**: Implements text rendering with position, font size, and RGBA color parameters, bridging Shimlang to macroquad's drawing API
- **Implemented JS↔WASM source bridge**: Added `shimlang_bridge.js` plugin that enables the host page to pass Shimlang source code to the WASM runtime via `window.__shimlang_pending_source` and `window.__shimlang_source_ready` flags
- **Refactored script loading logic**: 
  - On WASM targets: Polls for pending source each frame via `try_take_pending_source()` instead of loading once at startup
  - On native targets: Maintains existing file-based auto-reload behavior with mtime tracking
  - Unified both paths into a single main loop structure

## Implementation Details
- The `shimlang_bridge.js` plugin registers two extern functions (`shimlang_source_len` and `shimlang_take_source`) that handle UTF-8 encoding and WASM memory management
- The bridge uses a miniquad plugin system to inject the source-passing functions into the WASM import object
- Script loading errors are collected in `script_errors` vector for both hot-reload paths
- The `draw_text` function validates UTF-8 encoding and properly handles color values as RGBA components

https://claude.ai/code/session_01FyjekTbs6989m45qiC5ZZG