### PR TITLE
Shimlang: Update VS Code grammar for new syntax

### DIFF
--- a/shimlang-vscode/README.md
+++ b/shimlang-vscode/README.md
@@ -9,8 +9,11 @@ Syntax highlighting for the [Shimlang](../shimlang/) programming language (`.shm
 - Nested string interpolation — code inside `\(expr)` blocks is highlighted as code, not as a string
 - Keywords, constants (`true`, `false`, `None`), and operators
 - Numeric literals (integers and floats)
+- Tuples and tuple unpacking in `for` loops (`for x, y in pairs`)
+- `in` membership operator (`key in dict`, `value in list`, `substr in string`)
 - Function and struct definitions
-- `self` keyword
+- Built-in functions (`print`, `assert`, `panic`, `dict`, `Range`, `str`, `int`, `float`, `try_int`, `try_float`)
+- `self` keyword and dunder attributes (`__name__`, `__type__`)
 
 ## Build .vsix File
 
@@ -56,5 +59,7 @@ shimlang-vscode/
         ├── numbers_constants.shm
         ├── functions_structs.shm
         ├── operators.shm
+        ├── tuples.shm
+        ├── builtins.shm
         └── nested_features.shm
 ```

--- a/shimlang-vscode/package.json
+++ b/shimlang-vscode/package.json
@@ -2,7 +2,7 @@
     "name": "shimlang",
     "displayName": "Shimlang",
     "description": "Syntax highlighting for the Shimlang programming language",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "engines": {
         "vscode": "^1.75.0"
     },

--- a/shimlang-vscode/syntaxes/shimlang.tmLanguage.json
+++ b/shimlang-vscode/syntaxes/shimlang.tmLanguage.json
@@ -11,8 +11,10 @@
         { "include": "#keywords" },
         { "include": "#constants" },
         { "include": "#numbers" },
+        { "include": "#builtin-functions" },
         { "include": "#function-call" },
         { "include": "#self-keyword" },
+        { "include": "#dunder-attribute" },
         { "include": "#operators" },
         { "include": "#round-braces" },
         { "include": "#square-braces" },
@@ -97,7 +99,7 @@
             "patterns": [
                 {
                     "name": "keyword.control.shim",
-                    "match": "\\b(if|else|while|for|in|break|continue|return)\\b"
+                    "match": "\\b(if|else|while|for|break|continue|return)\\b"
                 },
                 {
                     "name": "keyword.other.let.shim",
@@ -105,7 +107,7 @@
                 },
                 {
                     "name": "keyword.operator.logical.shim",
-                    "match": "\\b(and|or)\\b"
+                    "match": "\\b(and|or|in)\\b"
                 },
                 {
                     "name": "storage.type.function.shim",
@@ -145,6 +147,12 @@
                 }
             ]
         },
+        "builtin-functions": {
+            "match": "\\b(print|assert|panic|dict|Range|str|int|float|try_int|try_float)(?=\\s*\\()",
+            "captures": {
+                "1": { "name": "support.function.builtin.shim" }
+            }
+        },
         "function-call": {
             "match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)(?=\\s*\\()",
             "captures": {
@@ -154,6 +162,10 @@
         "self-keyword": {
             "name": "variable.language.self.shim",
             "match": "\\bself\\b"
+        },
+        "dunder-attribute": {
+            "name": "variable.language.dunder.shim",
+            "match": "\\b__[a-zA-Z_][a-zA-Z0-9_]*__\\b"
         },
         "operators": {
             "patterns": [

--- a/shimlang-vscode/tests/cases/builtins.shm
+++ b/shimlang-vscode/tests/cases/builtins.shm
@@ -1,0 +1,49 @@
+// SYNTAX TEST "source.shim"
+
+print("hello");
+// <- support.function.builtin.shim
+
+assert(1 == 1);
+// <- support.function.builtin.shim
+
+panic("nope");
+// <- support.function.builtin.shim
+
+let d = dict();
+//      ^^^^ support.function.builtin.shim
+
+for i in Range(0, 10) {
+//       ^^^^^ support.function.builtin.shim
+}
+
+let s = str(42);
+//      ^^^ support.function.builtin.shim
+
+let n = int("42");
+//      ^^^ support.function.builtin.shim
+
+let f = float("3.14");
+//      ^^^^^ support.function.builtin.shim
+
+let maybe_n = try_int("hello");
+//            ^^^^^^^ support.function.builtin.shim
+
+let maybe_f = try_float("hello");
+//            ^^^^^^^^^ support.function.builtin.shim
+
+// Non-builtin function calls remain plain function calls
+foo(1, 2);
+// <- entity.name.function.call.shim
+
+// Built-in identifier without parens is not specially highlighted
+let p = print;
+//      ^^^^^ variable.other.shim
+
+// Dunder attributes
+struct Animal { name }
+let dog = Animal("Buddy");
+print(Animal.__name__);
+//           ^^^^^^^^ variable.language.dunder.shim
+
+print(dog.__type__);
+//        ^^^^^^^^ variable.language.dunder.shim

--- a/shimlang-vscode/tests/cases/functions_structs.shm
+++ b/shimlang-vscode/tests/cases/functions_structs.shm
@@ -6,7 +6,7 @@ fn hello(name) {
 //      ^ punctuation.section.parens.begin.shim
 
     print("Hello " + name);
-//  ^^^^^ entity.name.function.call.shim
+//  ^^^^^ support.function.builtin.shim
 }
 
 fn add(a, b) {

--- a/shimlang-vscode/tests/cases/keywords.shm
+++ b/shimlang-vscode/tests/cases/keywords.shm
@@ -14,7 +14,7 @@ while true { }
 
 for i in lst { }
 // <- keyword.control.shim
-//    ^^ keyword.control.shim
+//    ^^ keyword.operator.logical.shim
 
 break;
 // <- keyword.control.shim

--- a/shimlang-vscode/tests/cases/tuples.shm
+++ b/shimlang-vscode/tests/cases/tuples.shm
@@ -1,0 +1,37 @@
+// SYNTAX TEST "source.shim"
+
+let pair = (1, 2);
+//         ^ punctuation.section.parens.begin.shim
+//          ^ constant.numeric.integer.shim
+//           ^ punctuation.separator.comma.shim
+//             ^ constant.numeric.integer.shim
+//              ^ punctuation.section.parens.end.shim
+
+let one = (1,);
+//        ^ punctuation.section.parens.begin.shim
+//         ^ constant.numeric.integer.shim
+//          ^ punctuation.separator.comma.shim
+//           ^ punctuation.section.parens.end.shim
+
+let empty = ();
+//          ^ punctuation.section.parens.begin.shim
+//           ^ punctuation.section.parens.end.shim
+
+let triple = (1, "two", 3.0);
+//           ^ punctuation.section.parens.begin.shim
+//            ^ constant.numeric.integer.shim
+//                ^ string.quoted.double.shim
+//                      ^^^ constant.numeric.float.shim
+
+// Tuple unpacking in for loop
+for x, y in pairs {
+// <- keyword.control.shim
+//  ^ variable.other.shim
+//   ^ punctuation.separator.comma.shim
+//     ^ variable.other.shim
+//       ^^ keyword.operator.logical.shim
+}
+
+// Membership test with in operator
+let has = key in d;
+//            ^^ keyword.operator.logical.shim


### PR DESCRIPTION
Reclassify `in` as a logical operator (used for both for-loops and
membership tests). Highlight built-in functions (print, assert, panic,
dict, Range, str, int, float, try_int, try_float) and dunder attributes
(__name__, __type__). Add grammar tests for tuples and builtins.