### PR TITLE
Shimlang: store root_env in Interpreter, add insert_native_fn helper

### DIFF
--- a/macroquad_playground/src/main.rs
+++ b/macroquad_playground/src/main.rs
@@ -383,50 +383,33 @@ fn try_take_pending_source() -> Option<Vec<u8>> {
     }
 }
 
-fn load_script(text: &[u8]) -> Result<(Interpreter, Environment, ShimValue), String> {
-    let interpreter_config = shimlang::Config::default();
+fn load_script(text: &[u8]) -> Result<(Interpreter, ShimValue), String> {
     let ast = shimlang::ast_from_text(text)?;
 
     let program = shimlang::compile_ast(&ast)?;
     let mut interpreter = shimlang::Interpreter::create(&shimlang::Config::default(), program);
-    let mut env = shimlang::Environment::new_with_builtins(&mut interpreter);
 
-    let builtins: &[(&[u8], Box<NativeFn>)] = &[
-        (b"draw_circle", Box::new(shim_draw_circle)),
-        (b"draw_rectangle", Box::new(shim_draw_rectangle)),
-        (b"draw_line", Box::new(shim_draw_line)),
-        (b"draw_text", Box::new(shim_draw_text)),
-        (b"clear_background", Box::new(shim_clear_background)),
-        (b"new_bloop", Box::new(shim_new_bloop)),
-    ];
-
-    for (name, func) in builtins {
-        let position = interpreter.mem.alloc_and_set(**func, &format!("builtin func {}", debug_u8s(name)));
-        env.insert_new(&mut interpreter, name.to_vec(), ShimValue::NativeFn(position));
-    }
+    interpreter.add_native_fn(b"draw_circle", shim_draw_circle);
+    interpreter.add_native_fn(b"draw_rectangle", shim_draw_rectangle);
+    interpreter.add_native_fn(b"draw_line", shim_draw_line);
+    interpreter.add_native_fn(b"draw_text", shim_draw_text);
+    interpreter.add_native_fn(b"clear_background", shim_clear_background);
+    interpreter.add_native_fn(b"new_bloop", shim_new_bloop);
 
     let key_val = interpreter.mem.alloc_native(KeyMap);
-    env.insert_new(&mut interpreter, b"key".to_vec(), key_val);
+    interpreter.insert_in_root_env(b"key", key_val);
 
     let mut pc = 0;
-    interpreter.execute_bytecode_extended(&mut pc, shimlang::ArgBundle::new(), &mut env)?;
-    interpreter.gc(&env);
+    interpreter.execute_root(&mut pc)?;
+    interpreter.gc();
 
-    // Technically this is an external reference that should be passed to the
-    // gc as a root, but since it's in the `env` it should already be marked.
-    let loop_fn = match env.get(&mut interpreter, b"loop") {
-        Some(func @ ShimValue::Fn(_)) => {
-            func
-        },
-        None => {
-            return Err("No loop function found".to_string());
-        },
-        _ => {
-            return Err("Identifier 'loop' is not a function".to_string());
-        },
+    let loop_fn = match interpreter.get_from_root_env(b"loop") {
+        Some(func @ ShimValue::Fn(_)) => func,
+        None => return Err("No loop function found".to_string()),
+        _ => return Err("Identifier 'loop' is not a function".to_string()),
     };
 
-    Ok((interpreter, env, loop_fn))
+    Ok((interpreter, loop_fn))
 }
 
 fn generate_bloop_wav(start_freq: f32, end_freq: f32) -> Vec<u8> {
@@ -487,7 +470,7 @@ async fn main() {
         SOUND_MANAGER.write(SoundManager::new());
     }
 
-    let (mut interpreter, mut env, mut loop_fn) = load_script(b"fn loop() {}").expect("Should be able to load hardcoded script");
+    let (mut interpreter, mut loop_fn) = load_script(b"fn loop() {}").expect("Should be able to load hardcoded script");
     let mut script_errors = Vec::new();
 
     #[cfg(not(target_arch = "wasm32"))]
@@ -504,7 +487,7 @@ async fn main() {
         if let Some(bytes) = try_take_pending_source() {
             match load_script(&bytes) {
                 Ok(res) => {
-                    (interpreter, env, loop_fn) = res;
+                    (interpreter, loop_fn) = res;
                     script_errors = Vec::new();
                 },
                 Err(msg) => {
@@ -558,7 +541,7 @@ async fn main() {
                         &mut new_env,
                     ) {
                         Err(msg) => script_errors.push(msg),
-                        Ok(_) => interpreter.gc(&env),
+                        Ok(_) => interpreter.gc(),
                     }
                 },
                 Err(msg) => {

--- a/macroquad_playground/src/main.rs
+++ b/macroquad_playground/src/main.rs
@@ -399,8 +399,7 @@ fn load_script(text: &[u8]) -> Result<(Interpreter, ShimValue), String> {
     let key_val = interpreter.mem.alloc_native(KeyMap);
     interpreter.insert_in_root_env(b"key", key_val);
 
-    let mut pc = 0;
-    interpreter.execute_root(&mut pc)?;
+    interpreter.execute()?;
     interpreter.gc();
 
     let loop_fn = match interpreter.get_from_root_env(b"loop") {

--- a/shimlang/src/bin/repro.rs
+++ b/shimlang/src/bin/repro.rs
@@ -39,13 +39,12 @@ fn run() -> Result<(), String> {
     };
     let program = shimlang::compile_ast(&ast)?;
     let mut interpreter = shimlang::Interpreter::create(&Config::default(), program);
-    let mut env = shimlang::Environment::new_with_builtins(&mut interpreter);
     let mut pc = 0;
 
     for _ in 0..3 {
-        match interpreter.execute_bytecode_extended(&mut pc, shimlang::ArgBundle::new(), &mut env) {
+        match interpreter.execute_root(&mut pc) {
             Ok(_) => {
-                interpreter.gc(&env);
+                interpreter.gc();
             }
             Err(msg) => {
                 eprintln!("{msg}");

--- a/shimlang/src/bin/repro.rs
+++ b/shimlang/src/bin/repro.rs
@@ -39,10 +39,9 @@ fn run() -> Result<(), String> {
     };
     let program = shimlang::compile_ast(&ast)?;
     let mut interpreter = shimlang::Interpreter::create(&Config::default(), program);
-    let mut pc = 0;
 
     for _ in 0..3 {
-        match interpreter.execute_root(&mut pc) {
+        match interpreter.execute() {
             Ok(_) => {
                 interpreter.gc();
             }

--- a/shimlang/src/bin/shm.rs
+++ b/shimlang/src/bin/shm.rs
@@ -124,8 +124,7 @@ fn run() -> Result<(), String> {
                 };
                 let program = shimlang::compile_ast(&ast)?;
                 let mut interpreter = shimlang::Interpreter::create(&Config::default(), program);
-                let mut pc = 0;
-                match interpreter.execute_root(&mut pc) {
+                match interpreter.execute() {
                     Ok(_) => {
                         if args.gc {
                             interpreter.gc();
@@ -195,7 +194,7 @@ fn run() -> Result<(), String> {
             let program = shimlang::compile_ast(&ast)?;
 
             interpreter.append_program(program)?;
-            match interpreter.execute_root(&mut pc) {
+            match interpreter.execute_at(&mut pc) {
                 Ok(shimlang::ShimValue::None) => (),
                 Ok(val) => {
                     println!("{}", val.to_string(&mut interpreter));

--- a/shimlang/src/bin/shm.rs
+++ b/shimlang/src/bin/shm.rs
@@ -124,16 +124,11 @@ fn run() -> Result<(), String> {
                 };
                 let program = shimlang::compile_ast(&ast)?;
                 let mut interpreter = shimlang::Interpreter::create(&Config::default(), program);
-                let mut env = shimlang::Environment::new_with_builtins(&mut interpreter);
                 let mut pc = 0;
-                match interpreter.execute_bytecode_extended(
-                    &mut pc,
-                    shimlang::ArgBundle::new(),
-                    &mut env,
-                ) {
+                match interpreter.execute_root(&mut pc) {
                     Ok(_) => {
                         if args.gc {
-                            interpreter.gc(&env);
+                            interpreter.gc();
                         }
                     }
                     Err(msg) => {
@@ -177,7 +172,6 @@ fn run() -> Result<(), String> {
         let ast = shimlang::ast_from_text(b"").unwrap();
         let program = shimlang::compile_ast(&ast)?;
         let mut interpreter = shimlang::Interpreter::create(&Config::default(), program);
-        let mut env = shimlang::Environment::new_with_builtins(&mut interpreter);
 
         let mut pc = 0;
 
@@ -201,11 +195,7 @@ fn run() -> Result<(), String> {
             let program = shimlang::compile_ast(&ast)?;
 
             interpreter.append_program(program)?;
-            match interpreter.execute_bytecode_extended(
-                &mut pc,
-                shimlang::ArgBundle::new(),
-                &mut env,
-            ) {
+            match interpreter.execute_root(&mut pc) {
                 Ok(shimlang::ShimValue::None) => (),
                 Ok(val) => {
                     println!("{}", val.to_string(&mut interpreter));

--- a/shimlang/src/runtime.rs
+++ b/shimlang/src/runtime.rs
@@ -215,8 +215,8 @@ impl Environment {
         }
     }
 
-    pub fn new_with_builtins(interpreter: &mut Interpreter) -> Self {
-        let mut env = Self::new(&mut interpreter.mem);
+    pub fn new_with_builtins(mem: &mut MMU) -> Self {
+        let mut env = Self::new(mem);
         let builtins: &[(&[u8], NativeFn)] = &[
             (b"print", shim_print),
             (b"panic", shim_panic),
@@ -233,20 +233,18 @@ impl Environment {
         ];
 
         for (name, func) in builtins {
-            env.insert_native_fn(interpreter, name, *func);
+            env.insert_native_fn(mem, name, *func);
         }
 
         env
     }
 
-    pub fn insert_native_fn(&mut self, interpreter: &mut Interpreter, name: &[u8], func: NativeFn) {
-        let position = interpreter
-            .mem
-            .alloc_and_set(func, &format!("native fn {}", debug_u8s(name)));
-        self.insert_new(interpreter, name.to_vec(), ShimValue::NativeFn(position));
+    pub fn insert_native_fn(&mut self, mem: &mut MMU, name: &[u8], func: NativeFn) {
+        let position = mem.alloc_and_set(func, &format!("native fn {}", debug_u8s(name)));
+        self.insert_new(mem, name.to_vec(), ShimValue::NativeFn(position));
     }
 
-    pub fn insert_new(&mut self, interpreter: &mut Interpreter, key: Vec<u8>, val: ShimValue) {
+    pub fn insert_new(&mut self, mem: &mut MMU, key: Vec<u8>, val: ShimValue) {
         assert!(
             key.len() <= u8::MAX as usize,
             "Key length {} exceeds maximum {}",
@@ -255,18 +253,18 @@ impl Environment {
         );
 
         // Check if key already exists in the current scope — update in place (upsert)
-        let scope: &EnvScope = unsafe { interpreter.mem.get(u24::from(self.current_scope)) };
-        if let Some(value_offset) = scope.scan_for_key(&interpreter.mem, &key) {
+        let scope: &EnvScope = unsafe { mem.get(u24::from(self.current_scope)) };
+        if let Some(value_offset) = scope.scan_for_key(mem, &key) {
             let (data, capacity) = (scope.data, scope.capacity);
             unsafe {
-                EnvScope::write_value_at(&mut interpreter.mem, data, capacity, value_offset, val);
+                EnvScope::write_value_at(mem, data, capacity, value_offset, val);
             }
             return;
         }
 
         // Read current scope header via raw pointer to avoid borrow issues
         let (data, capacity, used) = unsafe {
-            let scope_ptr: *mut EnvScope = interpreter.mem.mem_mut(
+            let scope_ptr: *mut EnvScope = mem.mem_mut(
                 usize::from(u24::from(self.current_scope)),
                 std::mem::size_of::<EnvScope>().div_ceil(8),
             ).as_mut_ptr() as *mut EnvScope;
@@ -288,7 +286,7 @@ impl Environment {
                 new_capacity *= 2;
             }
             let new_data =
-                EnvScope::realloc(&mut interpreter.mem, data, capacity, used, new_capacity);
+                EnvScope::realloc(mem, data, capacity, used, new_capacity);
             (new_data, new_capacity)
         } else {
             (data, capacity)
@@ -296,7 +294,7 @@ impl Environment {
 
         // Update scope header (data/capacity may have changed)
         unsafe {
-            let scope_ptr: *mut EnvScope = interpreter.mem.mem_mut(
+            let scope_ptr: *mut EnvScope = mem.mem_mut(
                 usize::from(u24::from(self.current_scope)),
                 std::mem::size_of::<EnvScope>().div_ceil(8),
             ).as_mut_ptr() as *mut EnvScope;
@@ -306,14 +304,14 @@ impl Environment {
 
         // Append entry: [len: u8][ident_bytes][value: ShimValue (8 bytes)]
         unsafe {
-            let buf = EnvScope::raw_bytes_mut_from(&mut interpreter.mem, data, capacity);
+            let buf = EnvScope::raw_bytes_mut_from(mem, data, capacity);
             let off = used as usize;
             buf[off] = key.len() as u8;
             buf[off + 1..off + 1 + key.len()].copy_from_slice(&key);
         }
         unsafe {
             EnvScope::write_value_at(
-                &mut interpreter.mem,
+                mem,
                 data,
                 capacity,
                 used as usize + 1 + key.len(),
@@ -323,7 +321,7 @@ impl Environment {
 
         // Update used in scope header
         unsafe {
-            let scope_ptr: *mut EnvScope = interpreter.mem.mem_mut(
+            let scope_ptr: *mut EnvScope = mem.mem_mut(
                 usize::from(u24::from(self.current_scope)),
                 std::mem::size_of::<EnvScope>().div_ceil(8),
             ).as_mut_ptr() as *mut EnvScope;
@@ -333,7 +331,7 @@ impl Environment {
 
     pub fn update(
         &mut self,
-        interpreter: &mut Interpreter,
+        mem: &mut MMU,
         key: &[u8],
         val: ShimValue,
     ) -> Result<(), String> {
@@ -346,24 +344,18 @@ impl Environment {
             }
 
             let (parent, data, capacity, value_offset) = unsafe {
-                let scope: &EnvScope = interpreter.mem.get(u24::from(current_scope_pos));
+                let scope: &EnvScope = mem.get(u24::from(current_scope_pos));
                 (
                     scope.parent,
                     scope.data,
                     scope.capacity,
-                    scope.scan_for_key(&interpreter.mem, key),
+                    scope.scan_for_key(mem, key),
                 )
             };
 
             if let Some(value_offset) = value_offset {
                 unsafe {
-                    EnvScope::write_value_at(
-                        &mut interpreter.mem,
-                        data,
-                        capacity,
-                        value_offset,
-                        val,
-                    );
+                    EnvScope::write_value_at(mem, data, capacity, value_offset, val);
                 }
                 return Ok(());
             }
@@ -374,7 +366,7 @@ impl Environment {
         Err(format!("Key {:?} not found in environment", key))
     }
 
-    pub fn get(&self, interpreter: &mut Interpreter, key: &[u8]) -> Option<ShimValue> {
+    pub fn get(&self, mem: &MMU, key: &[u8]) -> Option<ShimValue> {
         let mut current_scope_pos = self.current_scope;
 
         loop {
@@ -383,15 +375,15 @@ impl Environment {
             }
 
             let (parent, value_offset) = unsafe {
-                let scope: &EnvScope = interpreter.mem.get(u24::from(current_scope_pos));
-                (scope.parent, scope.scan_for_key(&interpreter.mem, key))
+                let scope: &EnvScope = mem.get(u24::from(current_scope_pos));
+                (scope.parent, scope.scan_for_key(mem, key))
             };
 
             if let Some(value_offset) = value_offset {
                 // Read the ShimValue from the byte offset
                 let val: ShimValue = unsafe {
-                    let scope: &EnvScope = interpreter.mem.get(u24::from(current_scope_pos));
-                    let bytes = scope.raw_bytes(&interpreter.mem);
+                    let scope: &EnvScope = mem.get(u24::from(current_scope_pos));
+                    let bytes = scope.raw_bytes(mem);
                     let mut val_bytes = [0u8; 8];
                     std::ptr::copy_nonoverlapping(
                         bytes[value_offset..].as_ptr(),
@@ -409,8 +401,8 @@ impl Environment {
         None
     }
 
-    fn contains_key(&self, interpreter: &mut Interpreter, key: &[u8]) -> bool {
-        self.get(interpreter, key).is_some()
+    fn contains_key(&self, mem: &MMU, key: &[u8]) -> bool {
+        self.get(mem, key).is_some()
     }
 
     fn push_scope(&mut self, mem: &mut MMU, captures: bool) {
@@ -2134,13 +2126,13 @@ impl Interpreter {
 
     pub fn gc(&mut self) {
         let _zone = zone_scoped!("GC");
-        let env = std::mem::take(&mut self.root_env);
+        let root_scope = self.root_env.current_scope;
 
         unsafe {
-            let _scope: &EnvScope = self.mem.get(u24::from(env.current_scope));
+            let _scope: &EnvScope = self.mem.get(u24::from(root_scope));
         }
 
-        let roots = vec![ShimValue::Environment(u24::from(env.current_scope))];
+        let roots = vec![ShimValue::Environment(u24::from(root_scope))];
 
         {
             let _zone = zone_scoped!("GC Mark and Sweep");
@@ -2152,29 +2144,24 @@ impl Interpreter {
             gc.sweep();
             gc.drop_orphaned_native_types();
         }
-
-        self.root_env = env;
     }
 
     pub fn create(config: &Config, program: Program) -> Self {
-        let mmu = MMU::with_capacity(u24::from(config.memory_space_bytes / 8));
+        let mut mmu = MMU::with_capacity(u24::from(config.memory_space_bytes / 8));
 
-        let mut interp = Self {
+        let root_env = Environment::new_with_builtins(&mut mmu);
+        Self {
             mem: mmu,
             source: HashMap::new(),
             program: Arc::new(program),
             singletons: HashMap::new(),
-            root_env: Environment::default(),
-        };
-        interp.root_env = Environment::new_with_builtins(&mut interp);
-        interp
+            root_env,
+        }
     }
 
     /// Add a native function to the interpreter's root environment.
     pub fn add_native_fn(&mut self, name: &[u8], func: NativeFn) {
-        let mut env = std::mem::take(&mut self.root_env);
-        env.insert_native_fn(self, name, func);
-        self.root_env = env;
+        self.root_env.insert_native_fn(&mut self.mem, name, func);
     }
 
     /// Execute bytecode using the stored root environment.
@@ -2186,23 +2173,15 @@ impl Interpreter {
     }
 
     pub fn insert_in_root_env(&mut self, key: &[u8], val: ShimValue) {
-        let mut env = std::mem::take(&mut self.root_env);
-        env.insert_new(self, key.to_vec(), val);
-        self.root_env = env;
+        self.root_env.insert_new(&mut self.mem, key.to_vec(), val);
     }
 
     pub fn update_in_root_env(&mut self, key: &[u8], val: ShimValue) -> Result<(), String> {
-        let mut env = std::mem::take(&mut self.root_env);
-        let result = env.update(self, key, val);
-        self.root_env = env;
-        result
+        self.root_env.update(&mut self.mem, key, val)
     }
 
     pub fn get_from_root_env(&mut self, key: &[u8]) -> Option<ShimValue> {
-        let env = std::mem::take(&mut self.root_env);
-        let val = env.get(self, key);
-        self.root_env = env;
-        val
+        self.root_env.get(&self.mem, key)
     }
 
     pub fn fetch_mut<T: Default + Send + 'static>(&mut self) -> &mut T {
@@ -2464,7 +2443,7 @@ impl Interpreter {
                         }
                         if let Some(idx) = found_idx {
                             let (_ident, val) = pending_args.kwargs.remove(idx);
-                            env.insert_new(self, param_name.to_vec(), val);
+                            env.insert_new(&mut self.mem, param_name.to_vec(), val);
                             set_arg = true;
                         }
 
@@ -2494,7 +2473,7 @@ impl Interpreter {
 
                                 ShimValue::Uninitialized
                             };
-                            env.insert_new(self, param_name.to_vec(), val);
+                            env.insert_new(&mut self.mem, param_name.to_vec(), val);
                         }
 
                         idx += 1 + len as usize;
@@ -2526,7 +2505,7 @@ impl Interpreter {
                     let optional_param_name = &fn_optional_param_names[fn_optional_param_name_idx];
                     fn_optional_param_name_idx += 1;
 
-                    match env.get(self, optional_param_name) {
+                    match env.get(&self.mem, optional_param_name) {
                         Some(ShimValue::Uninitialized) => (),
                         Some(_) => {
                             let new_pc =
@@ -2543,7 +2522,7 @@ impl Interpreter {
                 val if val == ByteCode::AssignArg as u8 => {
                     let arg_num = bytes[pc + 1] as usize;
                     let optional_param_name = &fn_optional_param_names[arg_num];
-                    env.update(self, optional_param_name, stack.pop().unwrap())?;
+                    env.update(&mut self.mem, optional_param_name, stack.pop().unwrap())?;
                     pc += 1;
                 }
                 val if val == ByteCode::LiteralShimValue as u8 => {
@@ -2571,7 +2550,7 @@ impl Interpreter {
                     let val = stack.pop().expect("Value for declaration");
                     let ident_len = bytes[pc + 1] as usize;
                     let ident = &bytes[pc + 2..pc + 2 + ident_len];
-                    env.insert_new(self, ident.to_vec(), val);
+                    env.insert_new(&mut self.mem, ident.to_vec(), val);
                     pc += 1 + ident_len;
                 }
                 val if val == ByteCode::Assignment as u8 => {
@@ -2579,21 +2558,21 @@ impl Interpreter {
                     let ident_len = bytes[pc + 1] as usize;
                     let ident = &bytes[pc + 2..pc + 2 + ident_len];
 
-                    if !env.contains_key(self, ident) {
+                    if !env.contains_key(&self.mem, ident) {
                         return Err(format_script_err(
                             self.program.spans[pc],
                             &self.program.script,
                             &format!("Identifier {:?} not found", ident),
                         ));
                     }
-                    env.update(self, ident, val)?;
+                    env.update(&mut self.mem, ident, val)?;
 
                     pc += 1 + ident_len;
                 }
                 val if val == ByteCode::VariableLoad as u8 => {
                     let ident_len = bytes[pc + 1] as usize;
                     let ident = &bytes[pc + 2..pc + 2 + ident_len];
-                    if let Some(value) = env.get(self, ident) {
+                    if let Some(value) = env.get(&self.mem, ident) {
                         stack.push(value);
                     } else {
                         return Err(format_script_err(
@@ -3072,8 +3051,8 @@ mod tests {
         let mut interpreter = test_interpreter();
         let mut env = Environment::new(&mut interpreter.mem);
 
-        env.insert_new(&mut interpreter, b"x".to_vec(), ShimValue::Integer(42));
-        let val = env.get(&mut interpreter, b"x");
+        env.insert_new(&mut interpreter.mem, b"x".to_vec(), ShimValue::Integer(42));
+        let val = env.get(&interpreter.mem, b"x");
         assert!(val.is_some());
         match val.unwrap() {
             ShimValue::Integer(42) => {}
@@ -3086,10 +3065,10 @@ mod tests {
         let mut interpreter = test_interpreter();
         let mut env = Environment::new(&mut interpreter.mem);
 
-        env.insert_new(&mut interpreter, b"y".to_vec(), ShimValue::Integer(1));
-        env.update(&mut interpreter, b"y", ShimValue::Integer(99))
+        env.insert_new(&mut interpreter.mem, b"y".to_vec(), ShimValue::Integer(1));
+        env.update(&mut interpreter.mem, b"y", ShimValue::Integer(99))
             .unwrap();
-        match env.get(&mut interpreter, b"y").unwrap() {
+        match env.get(&interpreter.mem, b"y").unwrap() {
             ShimValue::Integer(99) => {}
             other => panic!("Expected Integer(99), got {:?}", other),
         }
@@ -3101,32 +3080,32 @@ mod tests {
         let mut env = Environment::new(&mut interpreter.mem);
 
         env.insert_new(
-            &mut interpreter,
+            &mut interpreter.mem,
             b"root_var".to_vec(),
             ShimValue::Integer(10),
         );
         env.push_scope(&mut interpreter.mem, false);
         env.insert_new(
-            &mut interpreter,
+            &mut interpreter.mem,
             b"child_var".to_vec(),
             ShimValue::Integer(20),
         );
 
         // Can see child var
-        match env.get(&mut interpreter, b"child_var").unwrap() {
+        match env.get(&interpreter.mem, b"child_var").unwrap() {
             ShimValue::Integer(20) => {}
             other => panic!("Expected Integer(20), got {:?}", other),
         }
         // Can see parent var through scope chain
-        match env.get(&mut interpreter, b"root_var").unwrap() {
+        match env.get(&interpreter.mem, b"root_var").unwrap() {
             ShimValue::Integer(10) => {}
             other => panic!("Expected Integer(10), got {:?}", other),
         }
 
         // Pop scope and child var is gone
         env.pop_scope(&mut interpreter.mem).unwrap();
-        assert!(env.get(&mut interpreter, b"child_var").is_none());
-        match env.get(&mut interpreter, b"root_var").unwrap() {
+        assert!(env.get(&interpreter.mem, b"child_var").is_none());
+        match env.get(&interpreter.mem, b"root_var").unwrap() {
             ShimValue::Integer(10) => {}
             other => panic!("Expected Integer(10), got {:?}", other),
         }
@@ -3141,7 +3120,7 @@ mod tests {
         for i in 0..20u8 {
             let name = format!("var_{}", i);
             env.insert_new(
-                &mut interpreter,
+                &mut interpreter.mem,
                 name.into_bytes(),
                 ShimValue::Integer(i as i32),
             );
@@ -3149,7 +3128,7 @@ mod tests {
         // Verify all are retrievable
         for i in 0..20u8 {
             let name = format!("var_{}", i);
-            match env.get(&mut interpreter, name.as_bytes()).unwrap() {
+            match env.get(&interpreter.mem, name.as_bytes()).unwrap() {
                 ShimValue::Integer(v) if v == i as i32 => {}
                 other => panic!("Expected Integer({}), got {:?}", i, other),
             }

--- a/shimlang/src/runtime.rs
+++ b/shimlang/src/runtime.rs
@@ -2164,8 +2164,12 @@ impl Interpreter {
         self.root_env.insert_native_fn(&mut self.mem, name, func);
     }
 
-    /// Execute bytecode using the stored root environment.
-    pub fn execute_root(&mut self, pc: &mut usize) -> Result<ShimValue, String> {
+    pub fn execute(&mut self) -> Result<ShimValue, String> {
+        let mut pc = 0;
+        self.execute_at(&mut pc)
+    }
+
+    pub fn execute_at(&mut self, pc: &mut usize) -> Result<ShimValue, String> {
         let mut env = std::mem::take(&mut self.root_env);
         let result = self.execute_bytecode_extended(pc, ArgBundle::new(), &mut env);
         self.root_env = env;

--- a/shimlang/src/runtime.rs
+++ b/shimlang/src/runtime.rs
@@ -192,7 +192,7 @@ fn scan_for_key(bytes: &[u8], key: &[u8]) -> Option<usize> {
     None
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Environment {
     // Points to the current EnvScope in MMU
     // u32 is used as u24 converted to u32, 0 means no scope (empty environment)
@@ -217,29 +217,33 @@ impl Environment {
 
     pub fn new_with_builtins(interpreter: &mut Interpreter) -> Self {
         let mut env = Self::new(&mut interpreter.mem);
-        let builtins: &[(&[u8], Box<NativeFn>)] = &[
-            (b"print", Box::new(shim_print)),
-            (b"panic", Box::new(shim_panic)),
-            (b"dict", Box::new(shim_dict)),
-            (b"Range", Box::new(shim_range)),
-            (b"enumerate", Box::new(shim_enumerate)),
-            (b"average", Box::new(shim_average)),
-            (b"assert", Box::new(shim_assert)),
-            (b"str", Box::new(shim_str)),
-            (b"int", Box::new(shim_int)),
-            (b"float", Box::new(shim_float)),
-            (b"try_int", Box::new(shim_try_int)),
-            (b"try_float", Box::new(shim_try_float)),
+        let builtins: &[(&[u8], NativeFn)] = &[
+            (b"print", shim_print),
+            (b"panic", shim_panic),
+            (b"dict", shim_dict),
+            (b"Range", shim_range),
+            (b"enumerate", shim_enumerate),
+            (b"average", shim_average),
+            (b"assert", shim_assert),
+            (b"str", shim_str),
+            (b"int", shim_int),
+            (b"float", shim_float),
+            (b"try_int", shim_try_int),
+            (b"try_float", shim_try_float),
         ];
 
         for (name, func) in builtins {
-            let position = interpreter
-                .mem
-                .alloc_and_set(**func, &format!("builtin func {}", debug_u8s(name)));
-            env.insert_new(interpreter, name.to_vec(), ShimValue::NativeFn(position));
+            env.insert_native_fn(interpreter, name, *func);
         }
 
         env
+    }
+
+    pub fn insert_native_fn(&mut self, interpreter: &mut Interpreter, name: &[u8], func: NativeFn) {
+        let position = interpreter
+            .mem
+            .alloc_and_set(func, &format!("native fn {}", debug_u8s(name)));
+        self.insert_new(interpreter, name.to_vec(), ShimValue::NativeFn(position));
     }
 
     pub fn insert_new(&mut self, interpreter: &mut Interpreter, key: Vec<u8>, val: ShimValue) {
@@ -2037,6 +2041,7 @@ pub struct Interpreter {
     pub source: HashMap<String, String>,
     pub program: Arc<Program>,
     singletons: HashMap<TypeId, Box<dyn Any + Send>>,
+    pub root_env: Environment,
 }
 
 impl Interpreter {
@@ -2151,12 +2156,37 @@ impl Interpreter {
     pub fn create(config: &Config, program: Program) -> Self {
         let mmu = MMU::with_capacity(u24::from(config.memory_space_bytes / 8));
 
-        Self {
+        let mut interp = Self {
             mem: mmu,
             source: HashMap::new(),
             program: Arc::new(program),
             singletons: HashMap::new(),
-        }
+            root_env: Environment::default(),
+        };
+        interp.root_env = Environment::new_with_builtins(&mut interp);
+        interp
+    }
+
+    /// Add a native function to the interpreter's root environment.
+    pub fn add_native_fn(&mut self, name: &[u8], func: NativeFn) {
+        let mut env = std::mem::take(&mut self.root_env);
+        env.insert_native_fn(self, name, func);
+        self.root_env = env;
+    }
+
+    /// Run the GC using the stored root environment as the root.
+    pub fn gc_root(&mut self) {
+        let env = std::mem::take(&mut self.root_env);
+        self.gc(&env);
+        self.root_env = env;
+    }
+
+    /// Execute bytecode using the stored root environment.
+    pub fn execute_root(&mut self, pc: &mut usize) -> Result<ShimValue, String> {
+        let mut env = std::mem::take(&mut self.root_env);
+        let result = self.execute_bytecode_extended(pc, ArgBundle::new(), &mut env);
+        self.root_env = env;
+        result
     }
 
     pub fn fetch_mut<T: Default + Send + 'static>(&mut self) -> &mut T {

--- a/shimlang/src/runtime.rs
+++ b/shimlang/src/runtime.rs
@@ -2132,8 +2132,9 @@ impl Interpreter {
         }
     }
 
-    pub fn gc(&mut self, env: &Environment) {
+    pub fn gc(&mut self) {
         let _zone = zone_scoped!("GC");
+        let env = std::mem::take(&mut self.root_env);
 
         unsafe {
             let _scope: &EnvScope = self.mem.get(u24::from(env.current_scope));
@@ -2151,6 +2152,8 @@ impl Interpreter {
             gc.sweep();
             gc.drop_orphaned_native_types();
         }
+
+        self.root_env = env;
     }
 
     pub fn create(config: &Config, program: Program) -> Self {
@@ -2174,19 +2177,32 @@ impl Interpreter {
         self.root_env = env;
     }
 
-    /// Run the GC using the stored root environment as the root.
-    pub fn gc_root(&mut self) {
-        let env = std::mem::take(&mut self.root_env);
-        self.gc(&env);
-        self.root_env = env;
-    }
-
     /// Execute bytecode using the stored root environment.
     pub fn execute_root(&mut self, pc: &mut usize) -> Result<ShimValue, String> {
         let mut env = std::mem::take(&mut self.root_env);
         let result = self.execute_bytecode_extended(pc, ArgBundle::new(), &mut env);
         self.root_env = env;
         result
+    }
+
+    pub fn insert_in_root_env(&mut self, key: &[u8], val: ShimValue) {
+        let mut env = std::mem::take(&mut self.root_env);
+        env.insert_new(self, key.to_vec(), val);
+        self.root_env = env;
+    }
+
+    pub fn update_in_root_env(&mut self, key: &[u8], val: ShimValue) -> Result<(), String> {
+        let mut env = std::mem::take(&mut self.root_env);
+        let result = env.update(self, key, val);
+        self.root_env = env;
+        result
+    }
+
+    pub fn get_from_root_env(&mut self, key: &[u8]) -> Option<ShimValue> {
+        let env = std::mem::take(&mut self.root_env);
+        let val = env.get(self, key);
+        self.root_env = env;
+        val
     }
 
     pub fn fetch_mut<T: Default + Send + 'static>(&mut self) -> &mut T {

--- a/src/script_bridge.rs
+++ b/src/script_bridge.rs
@@ -1666,8 +1666,7 @@ fn load_script(bytes: &[u8]) -> Result<(Interpreter, ShimValue), String> {
     interpreter.insert_in_root_env(b"MOUSE_X1", ShimValue::Integer(4));
     interpreter.insert_in_root_env(b"MOUSE_X2", ShimValue::Integer(5));
 
-    let mut pc = 0;
-    interpreter.execute_root(&mut pc)?;
+    interpreter.execute()?;
     interpreter.gc();
 
     let loop_fn = match interpreter.get_from_root_env(b"loop") {

--- a/src/script_bridge.rs
+++ b/src/script_bridge.rs
@@ -1527,7 +1527,7 @@ fn value_from_json(
         },
         _ => {
             let val: &HashMap<_, _> = data.get().ok_or(format!("JSON data not an object"))?;
-            let ty = env.get(interpreter, type_name.as_bytes()).ok_or(format!("env has no type_name {type_name}"))?;
+            let ty = env.get(&interpreter.mem, type_name.as_bytes()).ok_or(format!("env has no type_name {type_name}"))?;
             let kwargs: Vec<(Ident, ShimValue)> = val.iter()
                 .map(|(key, value)| {
                     let shim_key = key.as_bytes().to_vec();

--- a/src/script_bridge.rs
+++ b/src/script_bridge.rs
@@ -668,7 +668,7 @@ impl DrawList {
 /// Messages sent from the Engine (Main Thread) to the Script Thread
 #[cfg(not(target_arch = "wasm32"))]
 pub enum ScriptRequest {
-    ExecuteLoop(Interpreter, Environment, ShimValue, Vec<u8>, Vec<u8>, f32, PerfTimer, Vec<u32>),
+    ExecuteLoop(Interpreter, ShimValue, Vec<u8>, Vec<u8>, f32, PerfTimer, Vec<u32>),
 }
 
 /// Messages sent from the Script Thread to the Engine
@@ -676,26 +676,25 @@ pub enum ScriptRequest {
 pub enum ScriptResponse {
     LoopComplete(
         Interpreter,
-        Environment,
         ShimValue,
         Vec<DrawListItem>,
         Vec<SoundCmd>,
         f32,
     ),
-    Error(Interpreter, Environment, ShimValue, String),
+    Error(Interpreter, ShimValue, String),
 }
 
 /// Messages sent from the file watcher thread to the Engine
 #[cfg(not(target_arch = "wasm32"))]
 enum ScriptWatcherMessage {
-    Loaded(Interpreter, Environment, ShimValue),
+    Loaded(Interpreter, ShimValue),
     Error(String),
 }
 
 enum BridgeState {
     #[cfg(not(target_arch = "wasm32"))]
     Running,
-    Paused(Box<Interpreter>, Environment, ShimValue),
+    Paused(Box<Interpreter>, ShimValue),
 }
 
 pub struct ScriptBridge {
@@ -1619,95 +1618,75 @@ fn shim_load_data(
     }
 }
 
-fn load_script(bytes: &[u8]) -> Result<(Interpreter, Environment, ShimValue), String> {
+fn load_script(bytes: &[u8]) -> Result<(Interpreter, ShimValue), String> {
     let ast = shimlang::ast_from_text(bytes)?;
     let program = shimlang::compile_ast(&ast)?;
     let mut interpreter = shimlang::Interpreter::create(&shimlang::Config::default(), program);
-    let mut env = shimlang::Environment::new_with_builtins(&mut interpreter);
 
-    let builtins: &[(&[u8], NativeFn)] = &[
-        (b"ig_begin", shim_ig_begin),
-        (b"ig_end", shim_ig_end),
-        (b"ig_text", shim_ig_text),
-        (b"draw_rect", shim_draw_rect),
-        (b"draw_text", shim_draw_text),
-        (b"text_size", shim_text_size),
-        (b"create_texture", shim_create_texture),
-        (b"Rect", shim_rect),
-        (b"window_size", shim_window_size),
-        (b"mouse_pos", shim_mouse_pos),
-        (b"mouse_pressed", shim_mouse_pressed),
-        (b"mouse_just_pressed", shim_mouse_just_pressed),
-        (b"mouse_just_released", shim_mouse_just_released),
-        (b"show_cursor", shim_show_cursor),
-        (b"hide_cursor", shim_hide_cursor),
-        (b"set_window_title", shim_set_window_title),
-        (b"mouse_focus", shim_mouse_focus),
-        (b"input_focus", shim_input_focus),
-        (b"rand", shim_rand),
-        (b"randi", shim_randi),
-        (b"play_square", shim_play_square),
-        (b"play_sine", shim_play_sine),
-        (b"create_sample", shim_create_sample),
-        (b"set_bus_gain", shim_set_bus_gain),
-        (b"set_bus_lowpass", shim_set_bus_lowpass),
-        (b"clear_bus_effects", shim_clear_bus_effects),
-        (b"reset_audio", shim_reset_audio),
-        (b"save_data", shim_save_data),
-        (b"load_data", shim_load_data),
-    ];
-    for (name, func) in builtins {
-        let position = interpreter.mem.alloc_and_set(
-            *func,
-            &format!("builtin imgui::{}", std::str::from_utf8(name).unwrap()),
-        );
-        env.insert_new(
-            &mut interpreter,
-            name.to_vec(),
-            ShimValue::NativeFn(position),
-        );
-    }
+    interpreter.add_native_fn(b"ig_begin", shim_ig_begin);
+    interpreter.add_native_fn(b"ig_end", shim_ig_end);
+    interpreter.add_native_fn(b"ig_text", shim_ig_text);
+    interpreter.add_native_fn(b"draw_rect", shim_draw_rect);
+    interpreter.add_native_fn(b"draw_text", shim_draw_text);
+    interpreter.add_native_fn(b"text_size", shim_text_size);
+    interpreter.add_native_fn(b"create_texture", shim_create_texture);
+    interpreter.add_native_fn(b"Rect", shim_rect);
+    interpreter.add_native_fn(b"window_size", shim_window_size);
+    interpreter.add_native_fn(b"mouse_pos", shim_mouse_pos);
+    interpreter.add_native_fn(b"mouse_pressed", shim_mouse_pressed);
+    interpreter.add_native_fn(b"mouse_just_pressed", shim_mouse_just_pressed);
+    interpreter.add_native_fn(b"mouse_just_released", shim_mouse_just_released);
+    interpreter.add_native_fn(b"show_cursor", shim_show_cursor);
+    interpreter.add_native_fn(b"hide_cursor", shim_hide_cursor);
+    interpreter.add_native_fn(b"set_window_title", shim_set_window_title);
+    interpreter.add_native_fn(b"mouse_focus", shim_mouse_focus);
+    interpreter.add_native_fn(b"input_focus", shim_input_focus);
+    interpreter.add_native_fn(b"rand", shim_rand);
+    interpreter.add_native_fn(b"randi", shim_randi);
+    interpreter.add_native_fn(b"play_square", shim_play_square);
+    interpreter.add_native_fn(b"play_sine", shim_play_sine);
+    interpreter.add_native_fn(b"create_sample", shim_create_sample);
+    interpreter.add_native_fn(b"set_bus_gain", shim_set_bus_gain);
+    interpreter.add_native_fn(b"set_bus_lowpass", shim_set_bus_lowpass);
+    interpreter.add_native_fn(b"clear_bus_effects", shim_clear_bus_effects);
+    interpreter.add_native_fn(b"reset_audio", shim_reset_audio);
+    interpreter.add_native_fn(b"save_data", shim_save_data);
+    interpreter.add_native_fn(b"load_data", shim_load_data);
 
     let key_val = interpreter.mem.alloc_native(KeyMap);
-    env.insert_new(&mut interpreter, b"key".to_vec(), key_val);
-    env.insert_new(&mut interpreter, b"delta".to_vec(), ShimValue::Float(0.0));
+    interpreter.insert_in_root_env(b"key", key_val);
+    interpreter.insert_in_root_env(b"delta", ShimValue::Float(0.0));
 
     let perf_module = interpreter.mem.alloc_native(PerfModule);
-    env.insert_new(&mut interpreter, b"perf".to_vec(), perf_module);
+    interpreter.insert_in_root_env(b"perf", perf_module);
 
-    let mouse_buttons: &[(&[u8], i32)] = &[
-        (b"MOUSE_LEFT", 1),
-        (b"MOUSE_MIDDLE", 2),
-        (b"MOUSE_RIGHT", 3),
-        (b"MOUSE_X1", 4),
-        (b"MOUSE_X2", 5),
-    ];
-    for (name, value) in mouse_buttons {
-        env.insert_new(&mut interpreter, name.to_vec(), ShimValue::Integer(*value));
-    }
+    interpreter.insert_in_root_env(b"MOUSE_LEFT", ShimValue::Integer(1));
+    interpreter.insert_in_root_env(b"MOUSE_MIDDLE", ShimValue::Integer(2));
+    interpreter.insert_in_root_env(b"MOUSE_RIGHT", ShimValue::Integer(3));
+    interpreter.insert_in_root_env(b"MOUSE_X1", ShimValue::Integer(4));
+    interpreter.insert_in_root_env(b"MOUSE_X2", ShimValue::Integer(5));
 
     let mut pc = 0;
-    interpreter.execute_bytecode_extended(&mut pc, shimlang::ArgBundle::new(), &mut env)?;
-    interpreter.gc(&env);
+    interpreter.execute_root(&mut pc)?;
+    interpreter.gc();
 
-    let loop_fn = match env.get(&mut interpreter, b"loop") {
+    let loop_fn = match interpreter.get_from_root_env(b"loop") {
         Some(func @ ShimValue::Fn(_)) => func,
         None => return Err("No loop function found".to_string()),
         _ => return Err("Identifier 'loop' is not a function".to_string()),
     };
 
-    Ok((interpreter, env, loop_fn))
+    Ok((interpreter, loop_fn))
 }
 
 fn call_loop_fn(
     interpreter: &mut Interpreter,
-    env: &mut Environment,
     loop_fn: ShimValue,
 ) -> Result<f32, String> {
     match loop_fn.call(interpreter, &mut shimlang::ArgBundle::new()) {
         Ok(CallResult::ReturnValue(_)) => {
             let gc_start = std::time::Instant::now();
-            interpreter.gc(env);
+            interpreter.gc();
             Ok(gc_start.elapsed().as_secs_f32())
         }
         Ok(CallResult::PC(pc, captured_scope)) => {
@@ -1720,7 +1699,7 @@ fn call_loop_fn(
                 Err(msg) => Err(msg),
                 Ok(_) => {
                     let gc_start = std::time::Instant::now();
-                    interpreter.gc(env);
+                    interpreter.gc();
                     Ok(gc_start.elapsed().as_secs_f32())
                 }
             }
@@ -1731,7 +1710,7 @@ fn call_loop_fn(
 
 impl ScriptBridge {
     pub fn new() -> Self {
-        let (interpreter, env, loop_fn) =
+        let (interpreter, loop_fn) =
             load_script(b"fn loop() {}").expect("Should be able to load hardcoded script");
         let script_path = crate::SCRIPT_PATH
             .lock()
@@ -1757,21 +1736,21 @@ impl ScriptBridge {
             // and skip the file-watcher thread entirely: hot-reload is pointless in a
             // fixed-frame CI run, and its spurious initial reload would reset the
             // interpreter state mid-run.
-            let (interpreter, env, loop_fn) = if headless {
+            let (interpreter, loop_fn) = if headless {
                 fs::read(&script_path)
                     .ok()
                     .and_then(|bytes| load_script(&bytes).ok())
-                    .unwrap_or((interpreter, env, loop_fn))
+                    .unwrap_or((interpreter, loop_fn))
             } else {
                 std::thread::spawn({
                     let path = script_path.clone();
                     move || file_watcher_logic(path, watcher_tx)
                 });
-                (interpreter, env, loop_fn)
+                (interpreter, loop_fn)
             };
 
             Self {
-                state: BridgeState::Paused(Box::new(interpreter), env, loop_fn),
+                state: BridgeState::Paused(Box::new(interpreter), loop_fn),
                 interpreter_errors: Vec::new(),
                 draw_list: Vec::new(),
                 sound_list: Vec::new(),
@@ -1785,13 +1764,13 @@ impl ScriptBridge {
 
         #[cfg(target_arch = "wasm32")]
         {
-            let (interpreter, env, loop_fn) = fs::read(&script_path)
+            let (interpreter, loop_fn) = fs::read(&script_path)
                 .ok()
                 .and_then(|bytes| load_script(&bytes).ok())
-                .unwrap_or((interpreter, env, loop_fn));
+                .unwrap_or((interpreter, loop_fn));
 
             Self {
-                state: BridgeState::Paused(Box::new(interpreter), env, loop_fn),
+                state: BridgeState::Paused(Box::new(interpreter), loop_fn),
                 interpreter_errors: Vec::new(),
                 draw_list: Vec::new(),
                 sound_list: Vec::new(),
@@ -1808,8 +1787,8 @@ impl ScriptBridge {
             // Apply any script reloads from the watcher thread
             while let Ok(msg) = self.watcher_rx.try_recv() {
                 match msg {
-                    ScriptWatcherMessage::Loaded(interpreter, env, loop_fn) => {
-                        self.state = BridgeState::Paused(Box::new(interpreter), env, loop_fn);
+                    ScriptWatcherMessage::Loaded(interpreter, loop_fn) => {
+                        self.state = BridgeState::Paused(Box::new(interpreter), loop_fn);
                         self.interpreter_errors = Vec::new();
                         crate::audio::submit(std::iter::once(SoundCmd::ResetAudio { fade_secs: 0.05 }));
                     }
@@ -1823,11 +1802,10 @@ impl ScriptBridge {
                 let state = mem::replace(&mut self.state, BridgeState::Running);
                 match state {
                     BridgeState::Running => panic!("Somehow the interpreter is running"),
-                    BridgeState::Paused(interpreter, env, loop_fn) => {
+                    BridgeState::Paused(interpreter, loop_fn) => {
                         self.tx
                             .send(ScriptRequest::ExecuteLoop(
                                 *interpreter,
-                                env,
                                 loop_fn,
                                 keys.to_vec(),
                                 last_keys.to_vec(),
@@ -1842,12 +1820,12 @@ impl ScriptBridge {
                 {
                     let _zone = zone_scoped!("Wait for interpreter response");
                     match self.rx.recv() {
-                        Ok(ScriptResponse::Error(interpreter, env, loop_fn, msg)) => {
-                            self.state = BridgeState::Paused(Box::new(interpreter), env, loop_fn);
+                        Ok(ScriptResponse::Error(interpreter, loop_fn, msg)) => {
+                            self.state = BridgeState::Paused(Box::new(interpreter), loop_fn);
                             self.interpreter_errors.push(msg);
                         }
-                        Ok(ScriptResponse::LoopComplete(interpreter, env, loop_fn, draw_list, sound_list, gc_time)) => {
-                            self.state = BridgeState::Paused(Box::new(interpreter), env, loop_fn);
+                        Ok(ScriptResponse::LoopComplete(interpreter, loop_fn, draw_list, sound_list, gc_time)) => {
+                            self.state = BridgeState::Paused(Box::new(interpreter), loop_fn);
                             self.draw_list = draw_list;
                             self.sound_list = sound_list;
                             self.last_gc_time = gc_time;
@@ -1890,7 +1868,7 @@ impl ScriptBridge {
         #[cfg(target_arch = "wasm32")]
         {
             if self.interpreter_errors.is_empty() {
-                if let BridgeState::Paused(ref mut interpreter, ref mut env, loop_fn) = self.state {
+                if let BridgeState::Paused(ref mut interpreter, loop_fn) = self.state {
                     let ks = interpreter.fetch_mut::<KeyState>();
                     ks.held_time.resize(keys.len(), 0.0);
                     for (i, &pressed) in keys.iter().enumerate() {
@@ -1911,8 +1889,8 @@ impl ScriptBridge {
                     ms.buttons = buttons;
                     *interpreter.fetch_mut::<PerfTimer>() = perf;
                     interpreter.fetch_mut::<SoundList>().finished.extend(finished.iter().copied());
-                    env.update(interpreter, b"delta", ShimValue::Float(delta)).expect("delta should be in env");
-                    match call_loop_fn(interpreter, env, loop_fn) {
+                    interpreter.update_in_root_env(b"delta", ShimValue::Float(delta)).expect("delta should be in env");
+                    match call_loop_fn(interpreter, loop_fn) {
                         Ok(gc_time) => self.last_gc_time = gc_time,
                         Err(msg) => self.interpreter_errors.push(msg),
                     }
@@ -1940,8 +1918,10 @@ impl ScriptBridge {
         match &mut self.state {
             #[cfg(not(target_arch = "wasm32"))]
             BridgeState::Running => {}
-            BridgeState::Paused(interpreter, env, _loop_fn) => {
-                shimlang_debug_window.debug_window(interpreter, env);
+            BridgeState::Paused(interpreter, _loop_fn) => {
+                let env = std::mem::take(&mut interpreter.root_env);
+                shimlang_debug_window.debug_window(interpreter, &env);
+                interpreter.root_env = env;
             }
         }
     }
@@ -1967,8 +1947,8 @@ fn file_watcher_logic(script_path: String, tx: Sender<ScriptWatcherMessage>) {
                                 Ok(bytes) => {
                                     println!("{}", debug_u8s(&bytes));
                                     let msg = match load_script(&bytes) {
-                                        Ok((interp, env, loop_fn)) => {
-                                            ScriptWatcherMessage::Loaded(interp, env, loop_fn)
+                                        Ok((interp, loop_fn)) => {
+                                            ScriptWatcherMessage::Loaded(interp, loop_fn)
                                         }
                                         Err(msg) => ScriptWatcherMessage::Error(msg),
                                     };
@@ -2013,7 +1993,7 @@ fn script_thread_logic(rx: Receiver<ScriptRequest>, tx: Sender<ScriptResponse>) 
     loop {
         if let Ok(request) = rx.recv() {
             match request {
-                ScriptRequest::ExecuteLoop(mut interpreter, mut env, loop_fn, keys, last_keys, delta, perf, finished) => {
+                ScriptRequest::ExecuteLoop(mut interpreter, loop_fn, keys, last_keys, delta, perf, finished) => {
                     let ks = interpreter.fetch_mut::<KeyState>();
                     ks.held_time.resize(keys.len(), 0.0);
                     for (i, &pressed) in keys.iter().enumerate() {
@@ -2034,8 +2014,8 @@ fn script_thread_logic(rx: Receiver<ScriptRequest>, tx: Sender<ScriptResponse>) 
                     ms.buttons = buttons;
                     *interpreter.fetch_mut::<PerfTimer>() = perf;
                     interpreter.fetch_mut::<SoundList>().finished.extend(finished.iter().copied());
-                    env.update(&mut interpreter, b"delta", ShimValue::Float(delta)).expect("delta should be in env");
-                    tx.send(match call_loop_fn(&mut interpreter, &mut env, loop_fn) {
+                    interpreter.update_in_root_env(b"delta", ShimValue::Float(delta)).expect("delta should be in env");
+                    tx.send(match call_loop_fn(&mut interpreter, loop_fn) {
                         Ok(gc_time) => {
                             let draw_list = interpreter
                                 .fetch_mut::<DrawList>()
@@ -2047,9 +2027,9 @@ fn script_thread_logic(rx: Receiver<ScriptRequest>, tx: Sender<ScriptResponse>) 
                                 .items
                                 .drain(..)
                                 .collect();
-                            ScriptResponse::LoopComplete(interpreter, env, loop_fn, draw_list, sound_list, gc_time)
+                            ScriptResponse::LoopComplete(interpreter, loop_fn, draw_list, sound_list, gc_time)
                         }
-                        Err(msg) => ScriptResponse::Error(interpreter, env, loop_fn, msg),
+                        Err(msg) => ScriptResponse::Error(interpreter, loop_fn, msg),
                     })
                     .unwrap();
                 }


### PR DESCRIPTION
- Interpreter::create now initializes and stores root_env via new_with_builtins,
  so callers no longer need to manage a separate Environment for the common case
- Add Interpreter::add_native_fn, execute_root, and gc_root as convenience
  wrappers that operate on the stored root_env (using mem::take to satisfy borrow
  checker)
- Add Environment::insert_native_fn to replace the manual alloc_and_set +
  insert_new two-step when registering native functions
- Simplify new_with_builtins to use insert_native_fn, removing Box<NativeFn>
- Derive Default for Environment (current_scope: 0 already means empty)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>