### PR TITLE
Add a debugger for shimlang (breakpoints, variable inspection, stepping)

### DIFF
--- a/shimlang/src/lex.rs
+++ b/shimlang/src/lex.rs
@@ -113,6 +113,19 @@ pub fn debug_u8s(data: &[u8]) -> &str {
     unsafe { std::str::from_utf8_unchecked(data) }
 }
 
+/// Map a byte offset within `script` to its 1-based source line number.
+/// Offsets at or past the end of the script map to the last line.
+pub fn byte_to_line(script: &[u8], offset: u32) -> u32 {
+    let mut line: u32 = 1;
+    let limit = (offset as usize).min(script.len());
+    for &c in &script[..limit] {
+        if c == b'\n' {
+            line += 1;
+        }
+    }
+    line
+}
+
 pub(crate) fn format_script_err(span: Span, script: &[u8], msg: &str) -> String {
     let script_lines = script_lines(script);
     let mut out = "".to_string();

--- a/shimlang/src/runtime.rs
+++ b/shimlang/src/runtime.rs
@@ -7,7 +7,7 @@ use shm_tracy::zone_scoped;
 use shm_tracy::*;
 
 use crate::compile::*;
-use crate::lex::{debug_u8s, format_script_err};
+use crate::lex::{byte_to_line, debug_u8s, format_script_err};
 use crate::mem::*;
 use crate::parse::*;
 use crate::shimlibs::*;
@@ -403,6 +403,52 @@ impl Environment {
 
     fn contains_key(&self, mem: &MMU, key: &[u8]) -> bool {
         self.get(mem, key).is_some()
+    }
+
+    /// Collect every variable visible in the current scope chain as `(name, value)`
+    /// pairs, walking from the innermost scope outward. When a name appears in more
+    /// than one scope the innermost (shadowing) binding wins. Intended for read-only
+    /// debugger inspection.
+    pub fn collect_vars(&self, mem: &MMU) -> Vec<(Vec<u8>, ShimValue)> {
+        let mut out: Vec<(Vec<u8>, ShimValue)> = Vec::new();
+        let mut seen: std::collections::HashSet<Vec<u8>> = std::collections::HashSet::new();
+        let mut current_scope_pos = self.current_scope;
+
+        while current_scope_pos != 0 {
+            let scope: &EnvScope = unsafe { mem.get(u24::from(current_scope_pos)) };
+            let parent: u32 = scope.parent.into();
+            let bytes = unsafe { scope.raw_bytes(mem) };
+
+            let mut offset = 0usize;
+            while offset < bytes.len() {
+                let key_len = bytes[offset] as usize;
+                let key_start = offset + 1;
+                let key_end = key_start + key_len;
+                let value_offset = key_end;
+                let entry_end = value_offset + 8;
+                if entry_end > bytes.len() {
+                    break;
+                }
+                let key = bytes[key_start..key_end].to_vec();
+                if seen.insert(key.clone()) {
+                    let val: ShimValue = unsafe {
+                        let mut val_bytes = [0u8; 8];
+                        std::ptr::copy_nonoverlapping(
+                            bytes[value_offset..].as_ptr(),
+                            val_bytes.as_mut_ptr(),
+                            8,
+                        );
+                        std::mem::transmute(val_bytes)
+                    };
+                    out.push((key, val));
+                }
+                offset = entry_end;
+            }
+
+            current_scope_pos = parent;
+        }
+
+        out
     }
 
     fn push_scope(&mut self, mem: &mut MMU, captures: bool) {
@@ -2027,6 +2073,99 @@ impl ShimValue {
     }
 }
 
+/// A hook the interpreter invokes once per source-line boundary while a script
+/// executes. It is the integration point for an external debugger (e.g. a UI on
+/// another thread): implementations inspect the read-only [`DebugContext`] and may
+/// block inside [`DebugHook::at_line`] to wait for user commands. Execution resumes
+/// when the call returns. The hook is `Send` so the owning [`Interpreter`] can move
+/// between threads.
+pub trait DebugHook: Send {
+    /// Called immediately before the first instruction of each new source line runs.
+    fn at_line(&mut self, ctx: &DebugContext);
+}
+
+/// A read-only view of the interpreter's live execution state, handed to a
+/// [`DebugHook`]. Accessors derive line numbers, locals, and the call stack from the
+/// current program counter, environment, and frame return addresses.
+pub struct DebugContext<'a> {
+    pc: usize,
+    interp: &'a Interpreter,
+    env: &'a Environment,
+    stack: &'a [ShimValue],
+    frame_return_pcs: &'a [usize],
+}
+
+impl<'a> DebugContext<'a> {
+    fn new(
+        pc: usize,
+        interp: &'a Interpreter,
+        env: &'a Environment,
+        stack: &'a [ShimValue],
+        frame_return_pcs: &'a [usize],
+    ) -> Self {
+        Self {
+            pc,
+            interp,
+            env,
+            stack,
+            frame_return_pcs,
+        }
+    }
+
+    fn line_of_pc(&self, pc: usize) -> u32 {
+        let spans = &self.interp.program.spans;
+        let pc = pc.min(spans.len().saturating_sub(1));
+        byte_to_line(&self.interp.program.script, spans[pc].start)
+    }
+
+    /// Program counter of the instruction about to execute.
+    pub fn pc(&self) -> usize {
+        self.pc
+    }
+
+    /// 1-based source line of the instruction about to execute.
+    pub fn line(&self) -> u32 {
+        self.line_of_pc(self.pc)
+    }
+
+    /// Number of active call frames (0 at top level).
+    pub fn call_depth(&self) -> usize {
+        self.frame_return_pcs.len()
+    }
+
+    /// Depth of the value/operand stack (mainly useful for diagnostics).
+    pub fn value_stack_depth(&self) -> usize {
+        self.stack.len()
+    }
+
+    /// The variables visible in the current scope chain as `(name, formatted value)`
+    /// pairs. Inner scopes shadow outer ones.
+    pub fn locals(&self) -> Vec<(String, String)> {
+        self.env
+            .collect_vars(&self.interp.mem)
+            .into_iter()
+            .map(|(name, val)| {
+                (
+                    String::from_utf8_lossy(&name).into_owned(),
+                    val.to_string_mem(&self.interp.mem),
+                )
+            })
+            .collect()
+    }
+
+    /// Source lines of the active call frames (the call sites), outermost first and
+    /// the current line appended last.
+    pub fn call_stack(&self) -> Vec<u32> {
+        let mut lines: Vec<u32> = self
+            .frame_return_pcs
+            .iter()
+            .map(|&ret_pc| self.line_of_pc(ret_pc))
+            .collect();
+        lines.push(self.line());
+        lines
+    }
+}
+
 // TODO: uncomment #[derive(Facet)]
 pub struct Interpreter {
     pub mem: MMU,
@@ -2034,6 +2173,9 @@ pub struct Interpreter {
     pub program: Arc<Program>,
     singletons: HashMap<TypeId, Box<dyn Any + Send>>,
     pub root_env: Environment,
+    /// Optional debugger hook, invoked at each source-line boundary during execution.
+    /// `None` (the default) means execution runs with no debugger overhead.
+    pub debug_hook: Option<Box<dyn DebugHook>>,
 }
 
 impl Interpreter {
@@ -2156,7 +2298,19 @@ impl Interpreter {
             program: Arc::new(program),
             singletons: HashMap::new(),
             root_env,
+            debug_hook: None,
         }
+    }
+
+    /// Attach a debugger hook to be invoked at each source-line boundary.
+    pub fn set_debug_hook(&mut self, hook: Box<dyn DebugHook>) {
+        self.debug_hook = Some(hook);
+    }
+
+    /// Detach and return the debugger hook, if any. Useful for moving a hook from a
+    /// retired interpreter onto a freshly (re)loaded one.
+    pub fn take_debug_hook(&mut self) -> Option<Box<dyn DebugHook>> {
+        self.debug_hook.take()
     }
 
     /// Add a native function to the interpreter's root environment.
@@ -2257,9 +2411,33 @@ impl Interpreter {
         let mut fn_optional_param_name_idx = 0;
         let mut fn_optional_param_names: Vec<Ident> = Vec::new();
 
+        // Tracks the last source line reported to the debugger so the hook fires once
+        // per line boundary rather than once per instruction.
+        let mut last_dbg_line: Option<u32> = None;
+
         let bytes = &self.program.clone().bytecode;
         while pc < bytes.len() {
             //let _zone = zone_scoped!("Execute Single Instruction");
+
+            // Debugger hook: only active when a hook is attached. Fires at the start of
+            // each new source line, letting an external debugger set breakpoints,
+            // inspect state, and step. The hook is taken out of `self` for the call so
+            // the read-only `DebugContext` can borrow `self` immutably.
+            if self.debug_hook.is_some() && pc < self.program.spans.len() {
+                let line = byte_to_line(&self.program.script, self.program.spans[pc].start);
+                if Some(line) != last_dbg_line {
+                    last_dbg_line = Some(line);
+                    let frame_return_pcs: Vec<usize> =
+                        stack_frame.iter().map(|frame| frame.0).collect();
+                    let mut hook = self.debug_hook.take();
+                    if let Some(hook) = hook.as_mut() {
+                        let ctx = DebugContext::new(pc, self, env, &stack, &frame_return_pcs);
+                        hook.at_line(&ctx);
+                    }
+                    self.debug_hook = hook;
+                }
+            }
+
             match bytes[pc] {
                 val if val == ByteCode::Pop as u8 => {
                     stack.pop();
@@ -3169,6 +3347,119 @@ mod tests {
 
         assert_eq!(interpreter.fetch_mut::<A>().0, 7);
         assert_eq!(interpreter.fetch_mut::<B>().0, "hello");
+    }
+
+    // ----- Debugger hook tests -----
+
+    use std::sync::Mutex;
+
+    #[derive(Default, Debug, Clone)]
+    struct DebugRecording {
+        /// (line, call_depth) at each line boundary the hook saw.
+        events: Vec<(u32, usize)>,
+        /// Locals captured when the hook reached `capture_locals_on`.
+        captured_locals: Vec<(String, String)>,
+    }
+
+    struct RecordingHook {
+        rec: Arc<Mutex<DebugRecording>>,
+        capture_locals_on: Option<u32>,
+    }
+
+    impl DebugHook for RecordingHook {
+        fn at_line(&mut self, ctx: &DebugContext) {
+            let mut rec = self.rec.lock().unwrap();
+            rec.events.push((ctx.line(), ctx.call_depth()));
+            if self.capture_locals_on == Some(ctx.line()) && rec.captured_locals.is_empty() {
+                rec.captured_locals = ctx.locals();
+            }
+        }
+    }
+
+    fn run_with_hook(src: &[u8], capture_locals_on: Option<u32>) -> DebugRecording {
+        let ast = crate::parse::ast_from_text(src).unwrap();
+        let program = crate::compile::compile_ast(&ast).unwrap();
+        let mut interpreter = Interpreter::create(&Config::default(), program);
+        let rec = Arc::new(Mutex::new(DebugRecording::default()));
+        interpreter.set_debug_hook(Box::new(RecordingHook {
+            rec: rec.clone(),
+            capture_locals_on,
+        }));
+        interpreter.execute().unwrap();
+        let guard = rec.lock().unwrap();
+        guard.clone()
+    }
+
+    /// Collapse consecutive duplicate lines so we can compare the visit order.
+    fn collapsed_lines(rec: &DebugRecording) -> Vec<u32> {
+        let mut out: Vec<u32> = Vec::new();
+        for &(line, _) in &rec.events {
+            if out.last() != Some(&line) {
+                out.push(line);
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn debug_hook_fires_per_line_in_order() {
+        let src = b"let x = 1;\nlet y = 2;\nlet z = x + y;\n";
+        let rec = run_with_hook(src, None);
+        // The statements are visited in order. (A trailing end-of-program instruction
+        // may map back to the block's start line, so only assert the prefix.)
+        assert!(
+            collapsed_lines(&rec).starts_with(&[1, 2, 3]),
+            "expected lines to start 1,2,3; got {:?}",
+            collapsed_lines(&rec)
+        );
+    }
+
+    #[test]
+    fn debug_hook_inspects_locals() {
+        // When the hook reaches line 3, `a` and `b` are in scope; `c` is not yet bound.
+        let src = b"let a = 10;\nlet b = 20;\nlet c = a + b;\n";
+        let rec = run_with_hook(src, Some(3));
+        let locals = rec.captured_locals;
+        assert!(
+            locals.contains(&("a".to_string(), "10".to_string())),
+            "expected a=10 in {locals:?}"
+        );
+        assert!(
+            locals.contains(&("b".to_string(), "20".to_string())),
+            "expected b=20 in {locals:?}"
+        );
+        assert!(
+            !locals.iter().any(|(name, _)| name == "c"),
+            "c should not be bound yet in {locals:?}"
+        );
+    }
+
+    #[test]
+    fn debug_hook_tracks_call_depth() {
+        // Inside the called function the call depth is deeper than at the call site,
+        // which is what step-over / step-out rely on.
+        let src =
+            b"fn add(x, y) {\n    let s = x + y;\n    s\n}\nlet r = add(1, 2);\n";
+        let rec = run_with_hook(src, None);
+
+        let depth_in_body = rec
+            .events
+            .iter()
+            .filter(|(line, _)| *line == 2 || *line == 3)
+            .map(|(_, depth)| *depth)
+            .max()
+            .expect("function body should have been visited");
+        let depth_at_call = rec
+            .events
+            .iter()
+            .find(|(line, _)| *line == 5)
+            .map(|(_, depth)| *depth)
+            .expect("call site line should have been visited");
+
+        assert!(
+            depth_in_body > depth_at_call,
+            "expected deeper call stack inside function: body={depth_in_body} call={depth_at_call}"
+        );
     }
 }
 

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -1,0 +1,310 @@
+//! Debugger support for the shimlang interpreter.
+//!
+//! The interpreter runs on its own thread (see [`crate::script_bridge`]). When
+//! debugging is enabled, the interpreter carries a [`ChannelDebugHook`] that the VM
+//! invokes at every source-line boundary. On hitting a breakpoint (or while stepping)
+//! the hook *blocks the interpreter thread* and services commands from a separate
+//! debug-UI thread over channels. Because inspection runs on the interpreter thread —
+//! where the live `Interpreter` state lives — no interpreter memory is shared and no
+//! locking of interpreter internals is required.
+//!
+//! Wire protocol:
+//! - the UI thread sends [`DebugCommand`]s (set/clear breakpoints, pause, continue, step);
+//! - the hook sends [`DebugEvent`]s (paused with a snapshot, or resumed).
+
+#[cfg(not(target_arch = "wasm32"))]
+use std::collections::HashSet;
+#[cfg(not(target_arch = "wasm32"))]
+use std::sync::mpsc::{Receiver, Sender, TryRecvError};
+
+#[cfg(not(target_arch = "wasm32"))]
+use shimlang::{DebugContext, DebugHook};
+
+/// A command sent from the debug UI to the interpreter thread.
+#[derive(Debug, Clone)]
+pub enum DebugCommand {
+    /// Set a breakpoint on a 1-based source line.
+    SetBreakpoint(u32),
+    /// Clear a breakpoint on a 1-based source line.
+    ClearBreakpoint(u32),
+    /// Pause at the next source line reached.
+    Pause,
+    /// Resume until the next breakpoint.
+    Continue,
+    /// Run until the next source line, descending into called functions.
+    StepInto,
+    /// Run until the next source line in the current function (skip over calls).
+    StepOver,
+    /// Run until the current function returns.
+    StepOut,
+}
+
+/// A snapshot of interpreter state captured when execution pauses.
+#[derive(Debug, Clone)]
+pub struct PauseInfo {
+    /// 1-based source line where execution is paused.
+    pub line: u32,
+    /// Variables in scope as `(name, formatted value)` pairs.
+    pub locals: Vec<(String, String)>,
+    /// Source lines of the active call frames (outermost first, current line last).
+    pub call_stack: Vec<u32>,
+}
+
+/// An event sent from the interpreter thread to the debug UI.
+#[derive(Debug, Clone)]
+pub enum DebugEvent {
+    /// Execution paused; carries a snapshot of the current state.
+    Paused(PauseInfo),
+    /// Execution resumed after a pause.
+    Resumed,
+}
+
+/// How the interpreter should proceed past the current line.
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Debug, Clone, Copy)]
+enum StepMode {
+    /// Run freely, stopping only at breakpoints.
+    Run,
+    /// Stop at the very next line boundary.
+    Pause,
+    /// Stop at the next line, including inside called functions.
+    StepInto,
+    /// Stop at the next line at or above this call depth.
+    StepOver(usize),
+    /// Stop once the call depth drops below this value.
+    StepOut(usize),
+}
+
+/// A [`DebugHook`] that bridges the interpreter to a debug UI over channels.
+///
+/// Owned by the `Interpreter`, it travels with the interpreter as it moves between
+/// threads. On hot-reload the hook is moved onto the fresh interpreter (see
+/// `ScriptBridge::step`) so breakpoints and channel endpoints survive.
+#[cfg(not(target_arch = "wasm32"))]
+pub struct ChannelDebugHook {
+    cmd_rx: Receiver<DebugCommand>,
+    event_tx: Sender<DebugEvent>,
+    breakpoints: HashSet<u32>,
+    mode: StepMode,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl ChannelDebugHook {
+    pub fn new(cmd_rx: Receiver<DebugCommand>, event_tx: Sender<DebugEvent>) -> Self {
+        Self {
+            cmd_rx,
+            event_tx,
+            breakpoints: HashSet::new(),
+            mode: StepMode::Run,
+        }
+    }
+
+    /// Apply a breakpoint/pause command to the local state. Returns false for commands
+    /// that are not breakpoint edits (so the caller can decide how to handle them).
+    fn apply_breakpoint_cmd(&mut self, cmd: &DebugCommand) -> bool {
+        match cmd {
+            DebugCommand::SetBreakpoint(line) => {
+                self.breakpoints.insert(*line);
+                true
+            }
+            DebugCommand::ClearBreakpoint(line) => {
+                self.breakpoints.remove(line);
+                true
+            }
+            DebugCommand::Pause => {
+                self.mode = StepMode::Pause;
+                true
+            }
+            _ => false,
+        }
+    }
+
+    /// Decide whether execution should stop at the current line.
+    fn should_stop(&self, line: u32, depth: usize) -> bool {
+        if self.breakpoints.contains(&line) {
+            return true;
+        }
+        match self.mode {
+            StepMode::Run => false,
+            StepMode::Pause => true,
+            StepMode::StepInto => true,
+            StepMode::StepOver(start_depth) => depth <= start_depth,
+            StepMode::StepOut(start_depth) => depth < start_depth,
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl DebugHook for ChannelDebugHook {
+    fn at_line(&mut self, ctx: &DebugContext) {
+        // Drain any commands that arrived while running (breakpoint edits / async pause).
+        loop {
+            match self.cmd_rx.try_recv() {
+                Ok(cmd) => {
+                    self.apply_breakpoint_cmd(&cmd);
+                }
+                Err(TryRecvError::Empty) => break,
+                // UI gone: detach behavior — keep running freely.
+                Err(TryRecvError::Disconnected) => {
+                    self.mode = StepMode::Run;
+                    return;
+                }
+            }
+        }
+
+        let line = ctx.line();
+        let depth = ctx.call_depth();
+        if !self.should_stop(line, depth) {
+            return;
+        }
+
+        // Report the pause with a fresh snapshot.
+        let info = PauseInfo {
+            line,
+            locals: ctx.locals(),
+            call_stack: ctx.call_stack(),
+        };
+        if self.event_tx.send(DebugEvent::Paused(info)).is_err() {
+            // UI gone while we were about to pause; run free.
+            self.mode = StepMode::Run;
+            return;
+        }
+
+        // Block the interpreter thread, servicing commands until told to resume.
+        loop {
+            match self.cmd_rx.recv() {
+                Ok(cmd) => {
+                    if self.apply_breakpoint_cmd(&cmd) {
+                        // Breakpoint edit / pause: stay paused, keep waiting.
+                        continue;
+                    }
+                    self.mode = match cmd {
+                        DebugCommand::Continue => StepMode::Run,
+                        DebugCommand::StepInto => StepMode::StepInto,
+                        DebugCommand::StepOver => StepMode::StepOver(depth),
+                        DebugCommand::StepOut => StepMode::StepOut(depth),
+                        // Handled above by apply_breakpoint_cmd.
+                        DebugCommand::SetBreakpoint(_)
+                        | DebugCommand::ClearBreakpoint(_)
+                        | DebugCommand::Pause => unreachable!(),
+                    };
+                    let _ = self.event_tx.send(DebugEvent::Resumed);
+                    return;
+                }
+                // UI gone: resume and run free.
+                Err(_) => {
+                    self.mode = StepMode::Run;
+                    return;
+                }
+            }
+        }
+    }
+}
+
+/// Spawn a minimal console debug UI on its own thread.
+///
+/// This is a placeholder driver demonstrating the protocol end-to-end: it reads
+/// breakpoints from the `SHIM_DEBUG_BREAK` env var (comma-separated line numbers) at
+/// startup, prints a snapshot whenever execution pauses, and reads single-line
+/// commands from stdin to drive stepping:
+///
+/// - `c` / `continue`  — continue
+/// - `s` / `step`      — step into
+/// - `n` / `next`      — step over
+/// - `o` / `out`       — step out
+/// - `b <line>`        — set breakpoint
+/// - `d <line>`        — clear breakpoint
+///
+/// A real UI (e.g. an imgui panel on the main thread) can be built against the same
+/// `Sender<DebugCommand>` / `Receiver<DebugEvent>` pair instead of using this.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn spawn_console_debug_ui(cmd_tx: Sender<DebugCommand>, event_rx: Receiver<DebugEvent>) {
+    use std::io::Write;
+
+    std::thread::spawn(move || {
+        // Seed breakpoints from the environment so a run can stop without prior input.
+        if let Ok(spec) = std::env::var("SHIM_DEBUG_BREAK") {
+            for part in spec.split(',') {
+                if let Ok(line) = part.trim().parse::<u32>() {
+                    let _ = cmd_tx.send(DebugCommand::SetBreakpoint(line));
+                }
+            }
+        }
+
+        let stdin = std::io::stdin();
+        while let Ok(event) = event_rx.recv() {
+            let info = match event {
+                DebugEvent::Resumed => continue,
+                DebugEvent::Paused(info) => info,
+            };
+
+            println!("\n── shimdbg: paused at line {} ──", info.line);
+            println!("call stack (lines): {:?}", info.call_stack);
+            if info.locals.is_empty() {
+                println!("locals: <none>");
+            } else {
+                println!("locals:");
+                for (name, value) in &info.locals {
+                    println!("  {name} = {value}");
+                }
+            }
+
+            // Read commands until one resumes execution.
+            loop {
+                print!("(shimdbg) ");
+                let _ = std::io::stdout().flush();
+                let mut line = String::new();
+                if stdin.read_line(&mut line).unwrap_or(0) == 0 {
+                    // EOF: detach and let the interpreter run free.
+                    let _ = cmd_tx.send(DebugCommand::Continue);
+                    return;
+                }
+                let mut parts = line.split_whitespace();
+                let resumed = match parts.next() {
+                    Some("c") | Some("continue") => {
+                        let _ = cmd_tx.send(DebugCommand::Continue);
+                        true
+                    }
+                    Some("s") | Some("step") => {
+                        let _ = cmd_tx.send(DebugCommand::StepInto);
+                        true
+                    }
+                    Some("n") | Some("next") => {
+                        let _ = cmd_tx.send(DebugCommand::StepOver);
+                        true
+                    }
+                    Some("o") | Some("out") => {
+                        let _ = cmd_tx.send(DebugCommand::StepOut);
+                        true
+                    }
+                    Some("b") => {
+                        if let Some(line) = parts.next().and_then(|n| n.parse::<u32>().ok()) {
+                            let _ = cmd_tx.send(DebugCommand::SetBreakpoint(line));
+                            println!("breakpoint set at line {line}");
+                        } else {
+                            println!("usage: b <line>");
+                        }
+                        false
+                    }
+                    Some("d") => {
+                        if let Some(line) = parts.next().and_then(|n| n.parse::<u32>().ok()) {
+                            let _ = cmd_tx.send(DebugCommand::ClearBreakpoint(line));
+                            println!("breakpoint cleared at line {line}");
+                        } else {
+                            println!("usage: d <line>");
+                        }
+                        false
+                    }
+                    Some(other) => {
+                        println!("unknown command: {other} (c/s/n/o/b <line>/d <line>)");
+                        false
+                    }
+                    None => false,
+                };
+                if resumed {
+                    break;
+                }
+            }
+        }
+    });
+}

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -215,9 +215,11 @@ impl DebugHook for ChannelDebugHook {
 /// - `b <line>`        — set breakpoint
 /// - `d <line>`        — clear breakpoint
 ///
-/// A real UI (e.g. an imgui panel on the main thread) can be built against the same
-/// `Sender<DebugCommand>` / `Receiver<DebugEvent>` pair instead of using this.
+/// The main debugger UI is the imgui panel in `ScriptBridge::render_debug_panel`; this
+/// console driver is an optional alternative built against the same
+/// `Sender<DebugCommand>` / `Receiver<DebugEvent>` pair (not spawned by default).
 #[cfg(not(target_arch = "wasm32"))]
+#[allow(dead_code)]
 pub fn spawn_console_debug_ui(cmd_tx: Sender<DebugCommand>, event_rx: Receiver<DebugEvent>) {
     use std::io::Write;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ use std::borrow::Cow;
 use std::fmt::Formatter;
 
 mod audio;
+mod debug;
 mod debug_draw;
 mod gpu;
 mod imgui;

--- a/src/script_bridge.rs
+++ b/src/script_bridge.rs
@@ -704,6 +704,9 @@ pub struct ScriptBridge {
     pub sound_list: Vec<SoundCmd>,
     pub last_gc_time: f32,
     script_path: String,
+    /// When true, the interpreter carries a debug hook and `step` runs in a
+    /// breakpoint-aware, non-blocking mode (see `step`).
+    debug_enabled: bool,
     #[cfg(not(target_arch = "wasm32"))]
     tx: Sender<ScriptRequest>,
     #[cfg(not(target_arch = "wasm32"))]
@@ -711,6 +714,13 @@ pub struct ScriptBridge {
     #[cfg(not(target_arch = "wasm32"))]
     watcher_rx: Receiver<ScriptWatcherMessage>,
 }
+
+/// How long `step` waits for the interpreter loop to finish before giving up for this
+/// frame when debugging is enabled. A fast loop completes well within this budget
+/// (same-frame result); when paused at a breakpoint the wait times out and the main
+/// thread renders the previous frame, keeping the window responsive.
+#[cfg(not(target_arch = "wasm32"))]
+const DEBUG_FRAME_BUDGET: std::time::Duration = std::time::Duration::from_millis(16);
 
 fn shim_ig_begin(interpreter: &mut Interpreter, args: &ArgBundle) -> Result<ShimValue, String> {
     let mut unpacker = ArgUnpacker::new(args);
@@ -1735,7 +1745,7 @@ impl ScriptBridge {
             // and skip the file-watcher thread entirely: hot-reload is pointless in a
             // fixed-frame CI run, and its spurious initial reload would reset the
             // interpreter state mid-run.
-            let (interpreter, loop_fn) = if headless {
+            let (mut interpreter, loop_fn) = if headless {
                 fs::read(&script_path)
                     .ok()
                     .and_then(|bytes| load_script(&bytes).ok())
@@ -1748,6 +1758,19 @@ impl ScriptBridge {
                 (interpreter, loop_fn)
             };
 
+            // Enable the debugger only on an explicit opt-in, and never in headless
+            // (CI) runs where deterministic per-frame output and a blocking step loop
+            // are required. When enabled, attach a hook to the interpreter and spawn a
+            // console debug UI on its own thread.
+            let debug_enabled = !headless && std::env::var("SHIM_DEBUG").is_ok();
+            if debug_enabled {
+                let (cmd_tx, cmd_rx) = channel::<crate::debug::DebugCommand>();
+                let (event_tx, event_rx) = channel::<crate::debug::DebugEvent>();
+                interpreter
+                    .set_debug_hook(Box::new(crate::debug::ChannelDebugHook::new(cmd_rx, event_tx)));
+                crate::debug::spawn_console_debug_ui(cmd_tx, event_rx);
+            }
+
             Self {
                 state: BridgeState::Paused(Box::new(interpreter), loop_fn),
                 interpreter_errors: Vec::new(),
@@ -1755,6 +1778,7 @@ impl ScriptBridge {
                 sound_list: Vec::new(),
                 last_gc_time: 0.0,
                 script_path,
+                debug_enabled,
                 tx: request_tx,
                 rx: response_rx,
                 watcher_rx,
@@ -1775,6 +1799,7 @@ impl ScriptBridge {
                 sound_list: Vec::new(),
                 last_gc_time: 0.0,
                 script_path,
+                debug_enabled: false,
             }
         }
     }
@@ -1782,7 +1807,9 @@ impl ScriptBridge {
     pub fn step(&mut self, keys: &[u8], last_keys: &[u8], delta: f32, perf: PerfTimer, finished: Vec<u32>) {
         let _zone = zone_scoped!("Run interpreter");
         #[cfg(not(target_arch = "wasm32"))]
-        {
+        if self.debug_enabled {
+            self.step_debug(keys, last_keys, delta, perf, finished);
+        } else {
             // Apply any script reloads from the watcher thread
             while let Ok(msg) = self.watcher_rx.try_recv() {
                 match msg {
@@ -1904,6 +1931,99 @@ impl ScriptBridge {
                         .drain(..)
                         .collect();
                 }
+            }
+        }
+    }
+
+    /// Breakpoint-aware, non-blocking variant of the per-frame step used when the
+    /// debugger is enabled.
+    ///
+    /// Unlike the default path, this does not block on the interpreter response.
+    /// A frame request is launched while idle; we then wait only up to
+    /// [`DEBUG_FRAME_BUDGET`] for it to finish. If the interpreter is paused at a
+    /// breakpoint the wait times out, we leave the request in flight, and the caller
+    /// renders the previous frame — so the main thread (and any main-thread UI) stays
+    /// responsive while a separate debug-UI thread inspects the paused interpreter.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn step_debug(
+        &mut self,
+        keys: &[u8],
+        last_keys: &[u8],
+        delta: f32,
+        perf: PerfTimer,
+        finished: Vec<u32>,
+    ) {
+        // Only apply reloads while idle: an in-flight (possibly paused) interpreter must
+        // not be discarded. Carry the debug hook over to the freshly loaded interpreter
+        // so breakpoints and channel endpoints survive a hot reload.
+        if matches!(self.state, BridgeState::Paused(..)) {
+            while let Ok(msg) = self.watcher_rx.try_recv() {
+                match msg {
+                    ScriptWatcherMessage::Loaded(mut interpreter, loop_fn) => {
+                        if let BridgeState::Paused(mut old, _) =
+                            mem::replace(&mut self.state, BridgeState::Running)
+                        {
+                            if let Some(hook) = old.take_debug_hook() {
+                                interpreter.set_debug_hook(hook);
+                            }
+                        }
+                        self.state = BridgeState::Paused(Box::new(interpreter), loop_fn);
+                        self.interpreter_errors = Vec::new();
+                        crate::audio::submit(std::iter::once(SoundCmd::ResetAudio {
+                            fade_secs: 0.05,
+                        }));
+                    }
+                    ScriptWatcherMessage::Error(msg) => {
+                        self.interpreter_errors.push(msg);
+                    }
+                }
+            }
+        }
+
+        if !self.interpreter_errors.is_empty() {
+            return;
+        }
+
+        // If idle, launch this frame's loop. If a request is already in flight (the
+        // interpreter is busy or paused at a breakpoint), don't send another one.
+        if matches!(self.state, BridgeState::Paused(..)) {
+            if let BridgeState::Paused(interpreter, loop_fn) =
+                mem::replace(&mut self.state, BridgeState::Running)
+            {
+                self.tx
+                    .send(ScriptRequest::ExecuteLoop(
+                        *interpreter,
+                        loop_fn,
+                        keys.to_vec(),
+                        last_keys.to_vec(),
+                        delta,
+                        perf,
+                        finished,
+                    ))
+                    .unwrap();
+            }
+        }
+
+        // Wait briefly for completion. A timeout means the loop is still running
+        // (typically paused at a breakpoint); keep the previous frame and try again next
+        // step.
+        let _zone = zone_scoped!("Wait for interpreter response (debug)");
+        match self.rx.recv_timeout(DEBUG_FRAME_BUDGET) {
+            Ok(ScriptResponse::Error(interpreter, loop_fn, msg)) => {
+                self.state = BridgeState::Paused(Box::new(interpreter), loop_fn);
+                self.interpreter_errors.push(msg);
+            }
+            Ok(ScriptResponse::LoopComplete(interpreter, loop_fn, draw_list, sound_list, gc_time)) => {
+                self.state = BridgeState::Paused(Box::new(interpreter), loop_fn);
+                self.draw_list = draw_list;
+                self.sound_list = sound_list;
+                self.last_gc_time = gc_time;
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                // Still running / paused at a breakpoint: leave the request in flight.
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                panic!("Script thread disconnected");
             }
         }
     }

--- a/src/script_bridge.rs
+++ b/src/script_bridge.rs
@@ -713,6 +713,29 @@ pub struct ScriptBridge {
     rx: Receiver<ScriptResponse>,
     #[cfg(not(target_arch = "wasm32"))]
     watcher_rx: Receiver<ScriptWatcherMessage>,
+    // ----- Debugger UI state (main thread) -----
+    #[cfg(not(target_arch = "wasm32"))]
+    debug_cmd_tx: Option<Sender<crate::debug::DebugCommand>>,
+    #[cfg(not(target_arch = "wasm32"))]
+    debug_event_rx: Option<Receiver<crate::debug::DebugEvent>>,
+    /// Whether the interpreter is currently paused at a breakpoint.
+    #[cfg(not(target_arch = "wasm32"))]
+    debug_paused: bool,
+    /// Latest snapshot received when execution paused.
+    #[cfg(not(target_arch = "wasm32"))]
+    debug_pause_info: Option<crate::debug::PauseInfo>,
+    /// UI mirror of the breakpoints set on the interpreter (1-based line numbers).
+    #[cfg(not(target_arch = "wasm32"))]
+    debug_breakpoints: std::collections::BTreeSet<u32>,
+    /// Nul-terminated text buffer backing the "add breakpoint" input field.
+    #[cfg(not(target_arch = "wasm32"))]
+    debug_bp_input: Vec<u8>,
+    /// Source lines of the running script, refreshed on each pause for the source view.
+    #[cfg(not(target_arch = "wasm32"))]
+    debug_source_lines: Vec<String>,
+    /// Whether to include native (engine builtin) functions in the locals view.
+    #[cfg(not(target_arch = "wasm32"))]
+    debug_show_natives: bool,
 }
 
 /// How long `step` waits for the interpreter loop to finish before giving up for this
@@ -721,6 +744,23 @@ pub struct ScriptBridge {
 /// thread renders the previous frame, keeping the window responsive.
 #[cfg(not(target_arch = "wasm32"))]
 const DEBUG_FRAME_BUDGET: std::time::Duration = std::time::Duration::from_millis(16);
+
+/// A user action collected while rendering the debug panel, applied after the imgui
+/// window is closed so rendering doesn't hold a mutable borrow of the bridge.
+#[cfg(not(target_arch = "wasm32"))]
+enum DebugUiAction {
+    Send(crate::debug::DebugCommand),
+    ToggleBreakpoint(u32),
+    RemoveBreakpoint(u32),
+    AddBreakpointFromInput,
+}
+
+/// Parse a 1-based line number from a nul-terminated input buffer.
+#[cfg(not(target_arch = "wasm32"))]
+fn parse_line_buf(buf: &[u8]) -> Option<u32> {
+    let end = buf.iter().position(|&b| b == 0).unwrap_or(buf.len());
+    std::str::from_utf8(&buf[..end]).ok()?.trim().parse::<u32>().ok()
+}
 
 fn shim_ig_begin(interpreter: &mut Interpreter, args: &ArgBundle) -> Result<ShimValue, String> {
     let mut unpacker = ArgUnpacker::new(args);
@@ -1763,13 +1803,15 @@ impl ScriptBridge {
             // are required. When enabled, attach a hook to the interpreter and spawn a
             // console debug UI on its own thread.
             let debug_enabled = !headless && std::env::var("SHIM_DEBUG").is_ok();
-            if debug_enabled {
+            let (debug_cmd_tx, debug_event_rx) = if debug_enabled {
                 let (cmd_tx, cmd_rx) = channel::<crate::debug::DebugCommand>();
                 let (event_tx, event_rx) = channel::<crate::debug::DebugEvent>();
                 interpreter
                     .set_debug_hook(Box::new(crate::debug::ChannelDebugHook::new(cmd_rx, event_tx)));
-                crate::debug::spawn_console_debug_ui(cmd_tx, event_rx);
-            }
+                (Some(cmd_tx), Some(event_rx))
+            } else {
+                (None, None)
+            };
 
             Self {
                 state: BridgeState::Paused(Box::new(interpreter), loop_fn),
@@ -1782,6 +1824,14 @@ impl ScriptBridge {
                 tx: request_tx,
                 rx: response_rx,
                 watcher_rx,
+                debug_cmd_tx,
+                debug_event_rx,
+                debug_paused: false,
+                debug_pause_info: None,
+                debug_breakpoints: std::collections::BTreeSet::new(),
+                debug_bp_input: vec![0u8; 16],
+                debug_source_lines: Vec::new(),
+                debug_show_natives: false,
             }
         }
 
@@ -1889,6 +1939,11 @@ impl ScriptBridge {
                     super::igEnd();
                 }
             }
+        }
+
+        #[cfg(not(target_arch = "wasm32"))]
+        if self.debug_enabled {
+            self.render_debug_panel();
         }
 
         #[cfg(target_arch = "wasm32")]
@@ -2006,9 +2061,15 @@ impl ScriptBridge {
 
         // Wait briefly for completion. A timeout means the loop is still running
         // (typically paused at a breakpoint); keep the previous frame and try again next
-        // step.
+        // step. While already paused, don't wait at all — the response can't arrive until
+        // we resume, so polling keeps the debug panel responsive.
         let _zone = zone_scoped!("Wait for interpreter response (debug)");
-        match self.rx.recv_timeout(DEBUG_FRAME_BUDGET) {
+        let budget = if self.debug_paused {
+            std::time::Duration::ZERO
+        } else {
+            DEBUG_FRAME_BUDGET
+        };
+        match self.rx.recv_timeout(budget) {
             Ok(ScriptResponse::Error(interpreter, loop_fn, msg)) => {
                 self.state = BridgeState::Paused(Box::new(interpreter), loop_fn);
                 self.interpreter_errors.push(msg);
@@ -2024,6 +2085,243 @@ impl ScriptBridge {
             }
             Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
                 panic!("Script thread disconnected");
+            }
+        }
+    }
+
+    /// Render the imgui debugger panel on the main thread and forward user actions to
+    /// the interpreter thread. Drains pause/resume events, shows the paused location,
+    /// source view, breakpoints, locals, and call stack, and provides step controls.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn render_debug_panel(&mut self) {
+        use crate::debug::{DebugCommand, DebugEvent};
+
+        // Drain pause/resume events coming from the interpreter thread.
+        if self.debug_event_rx.is_some() {
+            let mut newly_paused: Option<crate::debug::PauseInfo> = None;
+            let mut resumed = false;
+            while let Ok(event) = self.debug_event_rx.as_ref().unwrap().try_recv() {
+                match event {
+                    DebugEvent::Paused(info) => newly_paused = Some(info),
+                    DebugEvent::Resumed => resumed = true,
+                }
+            }
+            if let Some(info) = newly_paused {
+                // Refresh the source view from the running script file.
+                self.debug_source_lines = std::fs::read_to_string(&self.script_path)
+                    .map(|s| s.lines().map(|l| l.to_string()).collect())
+                    .unwrap_or_default();
+                self.debug_paused = true;
+                self.debug_pause_info = Some(info);
+            } else if resumed {
+                self.debug_paused = false;
+            }
+        }
+
+        // Snapshot read-only state so rendering can also collect mutating actions
+        // without holding a borrow of `self`.
+        let paused = self.debug_paused;
+        let info = self.debug_pause_info.clone();
+        let breakpoints: Vec<u32> = self.debug_breakpoints.iter().copied().collect();
+        let mut show_natives = self.debug_show_natives;
+        let mut actions: Vec<DebugUiAction> = Vec::new();
+
+        let cs = |s: &str| CString::new(s).unwrap_or_default();
+
+        let mut open = true;
+        unsafe {
+            macro_rules! ctrl_button {
+                ($label:expr, $enabled:expr, $cmd:expr) => {{
+                    let enabled = $enabled;
+                    if !enabled {
+                        super::igBeginDisabled();
+                    }
+                    if super::igButton($label.as_ptr()) {
+                        actions.push(DebugUiAction::Send($cmd));
+                    }
+                    if !enabled {
+                        super::igEndDisabled();
+                    }
+                }};
+            }
+
+            if super::igBegin(
+                c"Shimlang Debugger".as_ptr(),
+                &mut open as *mut bool,
+                IMGUI_WINDOW_FLAGS_NO_FOCUS_ON_APPEARING,
+            ) {
+                // Status line.
+                if paused {
+                    let line = info.as_ref().map(|i| i.line).unwrap_or(0);
+                    super::igTextColoredBC(
+                        0.1, 0.1, 0.1, 1.0, 1.0, 0.85, 0.2, 1.0,
+                        cs(&format!("PAUSED at line {line}")).as_ptr(),
+                    );
+                } else {
+                    super::igTextColoredBC(
+                        0.1, 0.1, 0.1, 1.0, 0.3, 0.8, 0.3, 1.0, c"RUNNING".as_ptr(),
+                    );
+                }
+
+                super::igSeparator();
+
+                // Step controls. Continue/Step* are only meaningful while paused; Pause
+                // only while running.
+                ctrl_button!(c"Continue", paused, DebugCommand::Continue);
+                super::igSameLine();
+                ctrl_button!(c"Step Into", paused, DebugCommand::StepInto);
+                super::igSameLine();
+                ctrl_button!(c"Step Over", paused, DebugCommand::StepOver);
+                super::igSameLine();
+                ctrl_button!(c"Step Out", paused, DebugCommand::StepOut);
+                super::igSameLine();
+                ctrl_button!(c"Pause", !paused, DebugCommand::Pause);
+
+                super::igSeparator();
+
+                // Breakpoints: add via the input field, remove via per-row buttons.
+                super::igText(c"Breakpoints (line):".as_ptr());
+                let entered = super::igInputText(
+                    c"##bp_input".as_ptr(),
+                    self.debug_bp_input.as_mut_ptr() as *mut core::ffi::c_char,
+                    self.debug_bp_input.len() as i32,
+                    IMGUI_INPUT_TEXT_FLAGS_CHARS_DECIMAL
+                        | IMGUI_INPUT_TEXT_FLAGS_ENTER_RETURNS_TRUE,
+                );
+                super::igSameLine();
+                let add_clicked = super::igButton(c"Add".as_ptr());
+                if entered || add_clicked {
+                    actions.push(DebugUiAction::AddBreakpointFromInput);
+                }
+                for &bp in &breakpoints {
+                    super::igText(cs(&format!("  line {bp}")).as_ptr());
+                    super::igSameLine();
+                    if super::igButton(cs(&format!("remove##bp{bp}")).as_ptr()) {
+                        actions.push(DebugUiAction::RemoveBreakpoint(bp));
+                    }
+                }
+
+                super::igSeparator();
+
+                // Source view: a window of lines around the paused line. Click the marker
+                // button to toggle a breakpoint on that line.
+                super::igText(c"Source:".as_ptr());
+                if paused {
+                    if let Some(info) = &info {
+                        let cur = info.line as usize;
+                        let total = self.debug_source_lines.len();
+                        if total > 0 {
+                            let start = cur.saturating_sub(12).max(1);
+                            let end = (cur + 12).min(total);
+                            for ln in start..=end {
+                                let text = &self.debug_source_lines[ln - 1];
+                                let marker = if breakpoints.contains(&(ln as u32)) {
+                                    "*"
+                                } else {
+                                    " "
+                                };
+                                if super::igButton(cs(&format!("{marker}##src{ln}")).as_ptr()) {
+                                    actions.push(DebugUiAction::ToggleBreakpoint(ln as u32));
+                                }
+                                super::igSameLine();
+                                if ln == cur {
+                                    super::igTextColoredBC(
+                                        0.1, 0.1, 0.1, 1.0, 1.0, 0.85, 0.2, 1.0,
+                                        cs(&format!("{ln:>4} > {text}")).as_ptr(),
+                                    );
+                                } else {
+                                    super::igText(cs(&format!("{ln:>4}   {text}")).as_ptr());
+                                }
+                            }
+                        }
+                    }
+                }
+
+                super::igSeparator();
+
+                // Locals + call stack.
+                super::igCheckbox(c"Show native fns".as_ptr(), &mut show_natives as *mut bool);
+                super::igText(c"Locals:".as_ptr());
+                if let Some(info) = &info {
+                    if super::igBeginTable(c"##locals".as_ptr(), 2) {
+                        super::igTableSetupColumn(c"Name".as_ptr());
+                        super::igTableSetupColumn(c"Value".as_ptr());
+                        super::igTableHeadersRow();
+                        for (name, value) in &info.locals {
+                            if !show_natives && value.starts_with("NativeFn") {
+                                continue;
+                            }
+                            super::igTableNextRow();
+                            super::igTableSetColumnIndex(0);
+                            super::igText(cs(name).as_ptr());
+                            super::igTableSetColumnIndex(1);
+                            super::igText(cs(value).as_ptr());
+                        }
+                        super::igEndTable();
+                    }
+
+                    super::igSeparator();
+                    super::igText(c"Call stack (innermost first):".as_ptr());
+                    for (depth, line) in info.call_stack.iter().rev().enumerate() {
+                        super::igText(cs(&format!("#{depth}  line {line}")).as_ptr());
+                    }
+                }
+
+                super::igEnd();
+            }
+        }
+
+        // Apply collected actions and forward commands to the interpreter thread.
+        self.debug_show_natives = show_natives;
+        for action in actions {
+            match action {
+                DebugUiAction::Send(cmd) => {
+                    let resumes = matches!(
+                        &cmd,
+                        DebugCommand::Continue
+                            | DebugCommand::StepInto
+                            | DebugCommand::StepOver
+                            | DebugCommand::StepOut
+                    );
+                    if let Some(tx) = &self.debug_cmd_tx {
+                        let _ = tx.send(cmd);
+                    }
+                    // Optimistically clear the paused flag so the panel and step loop
+                    // react immediately; the Resumed event confirms it.
+                    if resumes {
+                        self.debug_paused = false;
+                    }
+                }
+                DebugUiAction::ToggleBreakpoint(line) => {
+                    if self.debug_breakpoints.remove(&line) {
+                        if let Some(tx) = &self.debug_cmd_tx {
+                            let _ = tx.send(DebugCommand::ClearBreakpoint(line));
+                        }
+                    } else {
+                        self.debug_breakpoints.insert(line);
+                        if let Some(tx) = &self.debug_cmd_tx {
+                            let _ = tx.send(DebugCommand::SetBreakpoint(line));
+                        }
+                    }
+                }
+                DebugUiAction::RemoveBreakpoint(line) => {
+                    self.debug_breakpoints.remove(&line);
+                    if let Some(tx) = &self.debug_cmd_tx {
+                        let _ = tx.send(DebugCommand::ClearBreakpoint(line));
+                    }
+                }
+                DebugUiAction::AddBreakpointFromInput => {
+                    if let Some(line) = parse_line_buf(&self.debug_bp_input) {
+                        if self.debug_breakpoints.insert(line) {
+                            if let Some(tx) = &self.debug_cmd_tx {
+                                let _ = tx.send(DebugCommand::SetBreakpoint(line));
+                            }
+                        }
+                    }
+                    for b in self.debug_bp_input.iter_mut() {
+                        *b = 0;
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

Adds debugging support to the shimlang interpreter and a real Dear ImGui debugger panel in the game. You can set breakpoints, inspect variables, and step through script code while the game runs. Opt-in via the `SHIM_DEBUG` env var; off by default and never active in headless/CI or wasm builds.

The interpreter runs on its own thread and the debug UI renders on the main thread, communicating over channels — so when paused at a breakpoint, inspection runs on the interpreter thread (where the live state lives) with no shared interpreter memory and no locks.

## shimlang crate (UI-agnostic core)

- **`DebugHook` trait + read-only `DebugContext`** (`runtime.rs`): the bytecode VM calls `hook.at_line(ctx)` once per source-line boundary. `DebugContext` exposes `line()`, `call_depth()`, `locals()` (name → formatted value), and `call_stack()`.
- **`Interpreter`** gains an optional `debug_hook` with `set_debug_hook`/`take_debug_hook`; **zero overhead** when no hook is attached (a single `is_some()` check per instruction, and the per-line work only runs when a hook is present).
- **`Environment::collect_vars`** walks the scope chain for inspection; **`byte_to_line`** (`lex.rs`) maps source offsets to 1-based lines (reusing the existing line-scan logic). Values format via the existing `ShimValue::to_string_mem`.
- 3 unit tests: line-boundary ordering, locals inspection, and call-depth tracking.

## Game crate (channels + imgui panel)

- **`src/debug.rs`**: the channel protocol (`DebugCommand` / `DebugEvent` / `PauseInfo`) and `ChannelDebugHook`, which blocks the interpreter thread at a breakpoint and services step/inspect/continue commands. Supports breakpoints, step into/over/out (via call-depth), and pause/continue. A small stdin console driver is kept as an optional alternative.
- **`script_bridge.rs`**:
  - When `SHIM_DEBUG` is set (and not headless), attaches the hook and runs a **non-blocking, breakpoint-aware** step loop so the main render thread keeps drawing while paused. The hook is carried across hot reloads.
  - **`render_debug_panel`** — the imgui panel, rendered each frame on the main thread:
    - Status line (RUNNING / PAUSED at line N)
    - Step controls (Continue, Step Into, Step Over, Step Out, Pause) with appropriate disabled states
    - Breakpoints: add by line number, remove per-row, or toggle by clicking the source gutter marker
    - Source view around the paused line with the current line highlighted (refreshed from the script file on each pause)
    - Locals table (with an opt-in toggle for native builtins) and a call-stack list

## Usage

Run the game with `SHIM_DEBUG=1`. Optionally pre-seed a breakpoint for the (alternative) console driver with `SHIM_DEBUG_BREAK=42`. In the imgui panel, set breakpoints by line, then use the step buttons when execution pauses.

## Testing

- `cargo test -p shimlang` → 13 passed (includes the new debugger tests); both crates build warning-free.
- Note: the game crate can't link a *test* binary in this environment because it pulls in `shm-tracy` with the real Tracy externs (no native lib present) — a pre-existing limitation affecting all game-crate tests — so the core debugger behavior is covered by the shimlang-crate tests. The imgui panel itself needs a manual run with a display (`SHIM_DEBUG=1`) to exercise interactively.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012WRfYQQiA37KTtQzyorj7e)_