### PR TITLE
Add StopIteration sentinel for iterators

### DIFF
--- a/shimlang-vscode/README.md
+++ b/shimlang-vscode/README.md
@@ -7,7 +7,7 @@ Syntax highlighting for the [Shimlang](../shimlang/) programming language (`.shm
 - Line comments (`//`) and nested block comments (`/* */`)
 - String literals with escape sequences (`\n`, `\t`, `\\`, `\"`, `\'`)
 - Nested string interpolation — code inside `\(expr)` blocks is highlighted as code, not as a string
-- Keywords, constants (`true`, `false`, `None`), and operators
+- Keywords, constants (`true`, `false`, `None`, `StopIteration`), and operators
 - Numeric literals (integers and floats)
 - Tuples and tuple unpacking in `for` loops (`for x, y in pairs`)
 - `in` membership operator (`key in dict`, `value in list`, `substr in string`)

--- a/shimlang-vscode/syntaxes/shimlang.tmLanguage.json
+++ b/shimlang-vscode/syntaxes/shimlang.tmLanguage.json
@@ -132,6 +132,10 @@
                 {
                     "name": "constant.language.none.shim",
                     "match": "\\bNone\\b"
+                },
+                {
+                    "name": "constant.language.stop-iteration.shim",
+                    "match": "\\bStopIteration\\b"
                 }
             ]
         },

--- a/shimlang-vscode/tests/cases/numbers_constants.shm
+++ b/shimlang-vscode/tests/cases/numbers_constants.shm
@@ -26,3 +26,6 @@ false;
 
 None;
 // <- constant.language.none.shim
+
+StopIteration;
+// <- constant.language.stop-iteration.shim

--- a/shimlang/LANGUAGE.md
+++ b/shimlang/LANGUAGE.md
@@ -1960,11 +1960,31 @@ Output:
 
 An iterable is any value with an `iter` method. Calling `.iter()` returns an
 iterator object, and that iterator exposes a `next` method. `for` loops call
-`.iter()` for you and repeatedly call `.next()` until it returns `None`.
+`.iter()` for you and repeatedly call `.next()` until it returns the
+`StopIteration` sentinel.
+
+`StopIteration` is a built-in value, available in the global environment, that
+iterators return to signal that there are no more values. It is distinct from
+`None`, which means an iterator can legitimately yield `None` as one of its
+values without ending iteration early:
+
+```rust
+for value in [1, None, 3] {
+    print(value);
+}
+```
+
+Output:
+
+```
+1
+None
+3
+```
 
 Any struct that implements an `iter` method returning an iterator object can be
-used in `for` loops. The `next` method should return `None` to signal the end
-of iteration:
+used in `for` loops. The `next` method should return `StopIteration` to signal
+the end of iteration:
 
 ```rust
 struct Counter {
@@ -1977,7 +1997,7 @@ struct Counter {
 
     fn next(self) {
         if self.current >= self.max {
-            return None;
+            return StopIteration;
         }
         let val = self.current;
         self.current = self.current + 1;

--- a/shimlang/src/compile.rs
+++ b/shimlang/src/compile.rs
@@ -45,6 +45,7 @@ pub(crate) enum ByteCode {
     LiteralShimValue,
     LiteralString,
     LiteralNone,
+    LiteralStopIteration,
     CreateFn,
     CreateList,
     CreateStruct,
@@ -718,12 +719,13 @@ pub fn compile_statement(stmt_node: &StatementNode) -> Result<Vec<(u8, Span)>, S
             asm.push((0, expr.span));
             asm.push((0, expr.span));
 
-            // Copy the result of .next() so we can check if it's None
+            // Copy the result of .next() so we can check if it's the
+            // StopIteration sentinel
             asm.push((ByteCode::Copy as u8, expr.span));
-            asm.push((ByteCode::LiteralNone as u8, expr.span));
+            asm.push((ByteCode::LiteralStopIteration as u8, expr.span));
             asm.push((ByteCode::Equal as u8, expr.span));
 
-            // Jump to `LoopEnd` if calling .next() returns None
+            // Jump to `LoopEnd` if calling .next() returns StopIteration
             let none_check_idx = asm.len();
             asm.push((ByteCode::JmpNZ as u8, stmt_span));
             asm.push((0, stmt_span));
@@ -768,10 +770,10 @@ pub fn compile_statement(stmt_node: &StatementNode) -> Result<Vec<(u8, Span)>, S
 
             // This is the offset from none_check_idx that will get us
             // out of the loop. JmpNZ lands on a Pop that discards the
-            // leftover None left on the stack by the iterator check
-            // (Copy/None/Equal consumed only the duplicate). `break`
-            // jumps to LoopEnd below instead, where that None is not
-            // on the stack.
+            // leftover StopIteration left on the stack by the iterator
+            // check (Copy/StopIteration/Equal consumed only the
+            // duplicate). `break` jumps to LoopEnd below instead, where
+            // that sentinel is not on the stack.
             let pc_offset = u16_to_u8s(asm.len() as u16 - none_check_idx as u16);
             asm[none_check_idx + 1].0 = pc_offset[0];
             asm[none_check_idx + 2].0 = pc_offset[1];
@@ -1656,6 +1658,8 @@ pub fn format_asm(bytes: &[u8]) -> String {
             idx += len + 1;
         } else if *b == ByteCode::LiteralNone as u8 {
             out.push_str("None");
+        } else if *b == ByteCode::LiteralStopIteration as u8 {
+            out.push_str("StopIteration");
         } else if *b == ByteCode::CreateList as u8 {
             let list_size = ((bytes[idx + 1] as usize) << 8) + bytes[idx + 2] as usize;
             out.push_str(&format!("CreateList size={}", list_size));

--- a/shimlang/src/mem.rs
+++ b/shimlang/src/mem.rs
@@ -836,6 +836,7 @@ impl<'a> GC<'a> {
                     | ShimValue::Bool(_)
                     | ShimValue::Unit
                     | ShimValue::None
+                    | ShimValue::StopIteration
                     | ShimValue::Uninitialized => (),
                     ShimValue::Fn(fn_pos) => {
                         let pos: usize = fn_pos.into();

--- a/shimlang/src/runtime.rs
+++ b/shimlang/src/runtime.rs
@@ -242,6 +242,10 @@ impl Environment {
             env.insert_native_fn(mem, name, *func);
         }
 
+        // Sentinel value used by iterators to signal the end of iteration.
+        env.insert_new(mem, b"StopIteration".to_vec(), ShimValue::StopIteration)
+            .expect("out of memory registering StopIteration");
+
         env
     }
 
@@ -484,6 +488,10 @@ pub enum ShimValue {
     Uninitialized,
     Unit,
     None,
+    // Sentinel returned by iterators to signal that iteration has finished.
+    // This is distinct from `None` so that `None` can be a legitimate value
+    // produced by an iterator.
+    StopIteration,
     Integer(i32),
     Float(f32),
     Bool(bool),
@@ -878,6 +886,10 @@ impl ShimValue {
 
     pub fn is_none(&self) -> bool {
         matches!(self, ShimValue::None)
+    }
+
+    pub fn is_stop_iteration(&self) -> bool {
+        matches!(self, ShimValue::StopIteration)
     }
 
     pub fn hash(&self, interpreter: &mut Interpreter) -> Result<u32, String> {
@@ -1512,6 +1524,7 @@ impl ShimValue {
         match self {
             ShimValue::Uninitialized => "Uninitialized".to_string(),
             ShimValue::None => "None".to_string(),
+            ShimValue::StopIteration => "StopIteration".to_string(),
             ShimValue::Integer(i) => i.to_string(),
             ShimValue::Float(f) => format_float(*f),
             ShimValue::Bool(false) => "false".to_string(),
@@ -1705,6 +1718,7 @@ impl ShimValue {
                 Ok(a == b)
             }
             (ShimValue::None, ShimValue::None) => Ok(true),
+            (ShimValue::StopIteration, ShimValue::StopIteration) => Ok(true),
             (a @ ShimValue::List(_), b @ ShimValue::List(_)) => {
                 let a = a.list(interpreter)?;
                 let b = b.list(interpreter)?;
@@ -2604,6 +2618,9 @@ impl Interpreter {
                 }
                 val if val == ByteCode::LiteralNone as u8 => {
                     stack.push(ShimValue::None);
+                }
+                val if val == ByteCode::LiteralStopIteration as u8 => {
+                    stack.push(ShimValue::StopIteration);
                 }
                 val if val == ByteCode::Copy as u8 => {
                     stack.push(*stack.last().expect("non-empty stack"));

--- a/shimlang/src/shimlibs.rs
+++ b/shimlang/src/shimlibs.rs
@@ -28,7 +28,7 @@ impl ShimNative for ListIterator {
                 let itr: &mut ListIterator = args.args[0].as_native(interpreter)?;
                 let lst = itr.lst.list(interpreter)?;
                 if itr.idx >= lst.len() {
-                    Ok(ShimValue::None)
+                    Ok(ShimValue::StopIteration)
                 } else {
                     let result = lst.get(&interpreter.mem, itr.idx as isize)?;
                     itr.idx += 1;
@@ -152,8 +152,8 @@ impl ShimNative for EnumeratorIterator {
                     }
                 };
 
-                if matches!(val, ShimValue::None) {
-                    return Ok(ShimValue::None);
+                if val.is_stop_iteration() {
+                    return Ok(ShimValue::StopIteration);
                 }
 
                 let itr: &mut EnumeratorIterator = args.args[0].as_native(interpreter)?;
@@ -197,7 +197,7 @@ impl ShimNative for StringIterator {
                 let b = {
                     let s = itr.str_val.string(interpreter)?;
                     if itr.idx >= s.len() {
-                        return Ok(ShimValue::None);
+                        return Ok(ShimValue::StopIteration);
                     }
                     s[itr.idx]
                 };
@@ -250,7 +250,7 @@ impl ShimNative for DictKeysIterator {
                     itr.idx += 1;
                 }
 
-                Ok(ShimValue::None)
+                Ok(ShimValue::StopIteration)
             }
 
             Ok(interpreter
@@ -318,7 +318,7 @@ impl ShimNative for DictValuesIterator {
                     itr.idx += 1;
                 }
 
-                Ok(ShimValue::None)
+                Ok(ShimValue::StopIteration)
             }
 
             Ok(interpreter
@@ -387,7 +387,7 @@ impl ShimNative for DictItemsIterator {
                     itr.idx += 1;
                 }
 
-                Ok(ShimValue::None)
+                Ok(ShimValue::StopIteration)
             }
 
             Ok(interpreter
@@ -561,7 +561,7 @@ impl ShimNative for RangeIterator {
                 };
 
                 if !has_more {
-                    Ok(ShimValue::None)
+                    Ok(ShimValue::StopIteration)
                 } else {
                     let result = itr.current;
                     // current = current + step
@@ -1442,7 +1442,7 @@ pub(crate) fn shim_average(
                 )?
             }
         };
-        if val.is_none() {
+        if val.is_stop_iteration() {
             break;
         }
         acc = match acc {
@@ -1809,7 +1809,7 @@ fn filter_iterable(
             }
         };
 
-        if input.is_none() {
+        if input.is_stop_iteration() {
             break;
         }
 
@@ -1995,8 +1995,8 @@ pub(crate) fn shim_list_extend(
             }
         };
 
-        // Break if we get None (end of iteration)
-        if result.is_none() {
+        // Break if we get StopIteration (end of iteration)
+        if result.is_stop_iteration() {
             break;
         }
 
@@ -2544,7 +2544,7 @@ pub(crate) fn shim_str_join(
                 interpreter.execute_bytecode_extended(&mut (pc as usize), next_args, &mut new_env)?
             }
         };
-        if item.is_none() {
+        if item.is_stop_iteration() {
             break;
         }
         if !first {
@@ -2836,6 +2836,7 @@ pub(crate) fn get_type_name(value: &ShimValue) -> &'static str {
         ShimValue::Uninitialized => "uninitialized",
         ShimValue::Unit => "unit",
         ShimValue::None => "none",
+        ShimValue::StopIteration => "stop_iteration",
         ShimValue::Integer(_) => "int",
         ShimValue::Float(_) => "float",
         ShimValue::Bool(_) => "bool",

--- a/shimlang/test_scripts/02_loops/custom_iterator_for.shm
+++ b/shimlang/test_scripts/02_loops/custom_iterator_for.shm
@@ -11,7 +11,7 @@ struct RangeIterator {
 
     fn next(self) {
         if self.idx == self.obj.stop {
-            return None;
+            return StopIteration;
         }
         let val = self.idx;
         self.idx = self.idx + 1;

--- a/shimlang/test_scripts/02_loops/custom_iterator_while.shm
+++ b/shimlang/test_scripts/02_loops/custom_iterator_while.shm
@@ -11,7 +11,7 @@ struct RangeIterator {
 
     fn next(self) {
         if self.idx == self.obj.stop {
-            return None;
+            return StopIteration;
         }
         let val = self.idx;
         self.idx = self.idx + 1;
@@ -32,7 +32,7 @@ let obj = Range(2, 8);
 let itr = obj.iter();
 while true {
     let val = itr.next();
-    if val == None {
+    if val == StopIteration {
         break;
     }
     print("Val:", val);

--- a/shimlang/test_scripts/06_list/list_extend_custom_iterator.shm
+++ b/shimlang/test_scripts/06_list/list_extend_custom_iterator.shm
@@ -11,7 +11,7 @@ struct Counter {
 
     fn next(self) {
         if self.current >= self.max {
-            return None;
+            return StopIteration;
         }
         let val = self.current;
         self.current = self.current + 1;

--- a/shimlang/test_scripts/06_list/list_none_element.shm
+++ b/shimlang/test_scripts/06_list/list_none_element.shm
@@ -1,0 +1,31 @@
+// A list may contain `None` as a genuine element. Iteration must yield those
+// `None` values rather than stopping early: iterators now signal the end of
+// iteration with the dedicated `StopIteration` sentinel, not with `None`.
+
+let lst = [1, None, 3, None, 5];
+
+// A `for` loop walks the whole list, including the `None` elements.
+for val in lst {
+    print(val);
+}
+
+// Indexing returns the stored `None` directly.
+print("index:", lst[1]);
+print("len:", lst.len());
+
+// `enumerate` also surfaces the `None` elements.
+for i, val in lst.enumerate() {
+    print(i, val);
+}
+
+// `filter` can keep `None` elements.
+let nones = filter(lst, fn(x) { x == None });
+print("filtered none count:", nones.len());
+
+// String joining renders `None` like any other element.
+print(",".join(lst));
+
+// `extend` consumes an iterator that yields `None`.
+let target = [0];
+target.extend([None, 6]);
+print("extended:", target.len(), target[1], target[2]);

--- a/shimlang/test_scripts/06_list/list_none_element.stdout
+++ b/shimlang/test_scripts/06_list/list_none_element.stdout
@@ -1,0 +1,15 @@
+1
+None
+3
+None
+5
+index: None
+len: 5
+0 1
+1 None
+2 3
+3 None
+4 5
+filtered none count: 2
+1,None,3,None,5
+extended: 3 None 6

--- a/shimlang/test_scripts/11_language_docs/language_smoke.shm
+++ b/shimlang/test_scripts/11_language_docs/language_smoke.shm
@@ -185,7 +185,7 @@ struct Counter {
 
     fn next(self) {
         if self.current >= self.max {
-            return None;
+            return StopIteration;
         }
         let val = self.current;
         self.current += 1;

--- a/shimlang/test_scripts/decompile/captured_block.stdout
+++ b/shimlang/test_scripts/decompile/captured_block.stdout
@@ -11,7 +11,7 @@
   58:  Copy
   59:  call args=0  kwargs=0
   62:  Copy
-  63:  None
+  63:  StopIteration
   64:  equal
   65:  JMPNZ -> 118
   68:  start_captured_scope

--- a/shimlang/test_scripts/decompile/for_loop.stdout
+++ b/shimlang/test_scripts/decompile/for_loop.stdout
@@ -11,7 +11,7 @@
   62:  Copy
   63:  call args=0  kwargs=0
   66:  Copy
-  67:  None
+  67:  StopIteration
   68:  equal
   69:  JMPNZ -> 102
   72:  start_scope


### PR DESCRIPTION
Introduce a dedicated StopIteration value so that None can be a legitimate value yielded by an iterator. Previously iterators signalled the end of iteration by returning None, which made it impossible to iterate over a collection containing None elements.

- Add ShimValue::StopIteration variant and expose StopIteration in the root environment.
- Add a LiteralStopIteration bytecode and have for-loops compare the result of .next() against StopIteration instead of None.
- Update all built-in iterators (list, string, enumerate, dict keys/values/ items, range) and iterator consumers (filter, average, extend, join) to use the new sentinel.
- Update custom-iterator test scripts and LANGUAGE.md to document that iterators return StopIteration.
- Add a test_scripts test covering lists with None elements across for loops, indexing, enumerate, filter, join, and extend.
- Add StopIteration to the VS Code TextMate grammar and its tests.


Claude-Session: https://claude.ai/code/session_012ADPMGUqFHfk8oqptEo1Mc