### PR TITLE
Fix multiline comment parsing when comment ends the file

### DIFF
--- a/shimlang/src/lex.rs
+++ b/shimlang/src/lex.rs
@@ -503,7 +503,7 @@ pub fn lex_multiline_comment_end_idx(text: &[u8]) -> Result<usize, String> {
     let mut depth = 1;
     let mut idx = 2;
 
-    while text.len() - idx > (depth * 2) {
+    while idx + 1 < text.len() {
         if text[idx] == b'/' && text[idx + 1] == b'*' {
             depth += 1;
             idx += 2;

--- a/shimlang/test_scripts/12_fixes/trailing_multiline_comment.shm
+++ b/shimlang/test_scripts/12_fixes/trailing_multiline_comment.shm
@@ -1,0 +1,4 @@
+print("before comment");
+/* this multiline comment
+   ends the file with no trailing newline,
+   and includes a /* nested */ comment */

--- a/shimlang/test_scripts/12_fixes/trailing_multiline_comment.stdout
+++ b/shimlang/test_scripts/12_fixes/trailing_multiline_comment.stdout
@@ -1,0 +1,1 @@
+before comment


### PR DESCRIPTION
The lexer's loop for finding the end of a multiline comment used the
condition `text.len() - idx > (depth * 2)`, which stopped iterating
before consuming the closing `*/` when the comment was the last thing in
the file. Each iteration only reads two bytes (text[idx] and
text[idx + 1]) regardless of nesting depth, so the correct condition is
`idx + 1 < text.len()`.

Add a regression test whose file ends exactly with a (nested) multiline
comment and no trailing newline.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0134Ye2ZkorVuhL2KbWFxWj1