### PR TITLE
Shimlang: fix re-lexing of trailing identifier at EOF

### DIFF
--- a/shimlang/src/lex.rs
+++ b/shimlang/src/lex.rs
@@ -356,8 +356,12 @@ pub fn lex_identifier(text: &mut &[u8]) -> Result<Vec<u8>, String> {
             }
         }
     }
-    // End of string - consume all of text
-    Ok(text.to_vec())
+    // End of string - consume all of text. Leave `text` one byte before the
+    // end so the caller's `+1` advance lands just past the consumed identifier,
+    // matching the non-end case above and `lex_number`.
+    let ident = text.to_vec();
+    *text = &text[(text.len() - 1)..];
+    Ok(ident)
 }
 
 pub enum StringLexResult {

--- a/shimlang/test_scripts/errors/var_does_not_exist.shm
+++ b/shimlang/test_scripts/errors/var_does_not_exist.shm
@@ -1,0 +1,1 @@
+let a = 12+does_not_exist

--- a/shimlang/test_scripts/errors/var_does_not_exist.stderr
+++ b/shimlang/test_scripts/errors/var_does_not_exist.stderr
@@ -1,0 +1,3 @@
+ 1 | let a = 12+does_not_exist
+                ^^^^^^^^^^^^^^
+Error: Unknown identifier "does_not_exist"


### PR DESCRIPTION
The main lexer loop advances one byte after each token, so every
sub-lexer must leave its cursor on the last byte it consumed.
`lex_identifier`'s end-of-input branch returned the identifier without
advancing the cursor, so when an identifier was the final token (no
trailing newline) the loop's single-byte advance only dropped the first
letter and re-lexed the rest, emitting a stream of bogus identifiers
(`does_not_exist`, `oes_not_exist`, ...). That surfaced as a confusing
parse error instead of the expected runtime "Unknown identifier" error.

Leave the cursor on the identifier's last byte, matching the non-EOF
branch and `lex_number`. Adds an error regression test.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0138MS7ZRcN8ccTFPwPTBLUz