### PR TITLE
Add dict printing support with {key: value} literal format

### DIFF
--- a/shimlang/src/runtime.rs
+++ b/shimlang/src/runtime.rs
@@ -1578,6 +1578,53 @@ impl ShimValue {
                 visited.pop();
                 out
             }
+            ShimValue::Dict(position) => {
+                let pos = usize::from(*position);
+                if visited.contains(&pos) {
+                    return "...".to_string();
+                }
+                visited.push(pos);
+
+                let out = unsafe {
+                    let dict: &ShimDict = &*(mem.mem().as_ptr().add(pos) as *const ShimDict);
+                    let entry_count = dict.entry_count as usize;
+                    let entries: &[DictEntry] = if entry_count == 0 {
+                        &[]
+                    } else {
+                        let entries_pos = usize::from(dict.entries);
+                        let u64_slice = &mem.mem()[entries_pos..entries_pos + 3 * entry_count];
+                        std::slice::from_raw_parts(
+                            u64_slice.as_ptr() as *const DictEntry,
+                            entry_count,
+                        )
+                    };
+
+                    let mut out = "{".to_string();
+                    let mut first = true;
+                    for entry in entries {
+                        if !entry.is_valid() {
+                            continue;
+                        }
+                        if first {
+                            first = false;
+                        } else {
+                            out.push_str(", ");
+                        }
+                        out.push_str(&entry.key.to_string_mem_inner(mem, visited));
+                        out.push_str(": ");
+                        out.push_str(&entry.value.to_string_mem_inner(mem, visited));
+                    }
+                    if first {
+                        // No entries were emitted: empty dict literal
+                        out.push(':');
+                    }
+                    out.push('}');
+                    out
+                };
+
+                visited.pop();
+                out
+            }
             ShimValue::Native(_, _) => self.native_from_mem(mem).unwrap().to_string_mem(mem),
             ShimValue::Struct(def_pos, pos) => {
                 let instance_pos = usize::from(*pos);

--- a/shimlang/test_scripts/04_dict/dict_print.shm
+++ b/shimlang/test_scripts/04_dict/dict_print.shm
@@ -1,0 +1,22 @@
+// Printing a dict renders the `{key: value}` literal form.
+
+// Empty dict
+let empty = {:}
+print(empty)
+
+// Single entry
+print({"a": 1})
+
+// Multiple entries (insertion order preserved)
+print({"key": "value", "another_key": "another_value"})
+
+// Integer keys and values
+print({1: 2, 3: 4})
+
+// Nested dict and list values
+print({"list": [1, 2, 3], "inner": {"x": 10}})
+
+// A dict that becomes empty after removing its only entry
+let d = {"only": 1}
+d.pop("only")
+print(d)

--- a/shimlang/test_scripts/04_dict/dict_print.stdout
+++ b/shimlang/test_scripts/04_dict/dict_print.stdout
@@ -1,0 +1,6 @@
+{:}
+{a: 1}
+{key: value, another_key: another_value}
+{1: 2, 3: 4}
+{list: [1, 2, 3], inner: {x: 10}}
+{:}


### PR DESCRIPTION
## Summary
This PR adds support for printing dictionaries in their literal form `{key: value}`, enabling proper string representation of dict values in the runtime.

## Key Changes
- **Dict string conversion**: Implemented `ShimValue::Dict` case in `to_string_mem_inner()` method to handle dictionary serialization
  - Detects and prevents infinite recursion by tracking visited positions
  - Safely accesses dict entries from memory using unsafe pointer arithmetic
  - Formats output as `{key: value, ...}` with proper comma separation
  - Special handling for empty dicts: renders as `{:}` to distinguish from empty blocks
  - Recursively converts keys and values, supporting nested structures

- **Test coverage**: Added comprehensive test script `dict_print.shm` validating:
  - Empty dictionaries
  - Single and multiple entries with insertion order preservation
  - Integer keys and values
  - Nested dicts and lists
  - Dicts that become empty after operations

## Implementation Details
- Uses unsafe memory access to read `ShimDict` structure and `DictEntry` array from heap
- Skips invalid entries during iteration (entries marked as deleted)
- Maintains a `visited` set to detect and handle circular references (returns `"..."`)
- Properly manages the visited stack by pushing before recursion and popping after

https://claude.ai/code/session_01WkzzVNZVE2J4vfWcCrZ2aA